### PR TITLE
feat(cli) : add offline diagnose command with safe fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "rich>=13.0.0",
     "pyyaml>=6.0.0",
     "python-dotenv>=1.0.0",
+    "pillow>=9.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ black>=24.0.0
 ruff>=0.8.0
 isort>=5.13.0
 pre-commit>=3.0.0
+pillow>=9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 anthropic>=0.18.0
 openai>=1.0.0
 requests>=2.32.4
+pillow>=9.0.0
 
 # Configuration
 PyYAML>=6.0.0

--- a/tests/test_diagnose_image.py
+++ b/tests/test_diagnose_image.py
@@ -1,0 +1,30 @@
+import pytest
+
+PIL = pytest.importorskip("PIL", reason="Pillow not installed")
+from PIL import Image
+
+from cortex.llm_router import LLMRouter
+
+
+def test_diagnose_image_fallback_without_claude():
+    """
+    If Claude is unavailable, diagnose_image should return
+    a safe fallback message instead of crashing.
+    """
+    router = LLMRouter(claude_api_key=None)
+
+    # Create a dummy image in memory
+    image = Image.new("RGB", (100, 100), color="red")
+
+    result = router.diagnose_image(image)
+
+    assert isinstance(result, str)
+    assert "Claude Vision unavailable" in result
+
+
+def test_llmrouter_has_diagnose_image_method():
+    """
+    Ensure diagnose_image exists on LLMRouter
+    """
+    router = LLMRouter()
+    assert hasattr(router, "diagnose_image")


### PR DESCRIPTION
### Summary
Adds a minimal MVP implementation of `cortex diagnose`.

### What’s included
- Text-based diagnosis command
- Offline-safe fallback (works without API keys)
- Graceful handling when no LLM provider is configured

### Why
- Enables error diagnosis on fresh systems
- Avoids forcing users to install LLM SDKs
- Matches MVP scope discussed in the issue

### Example
```bash
cortex diagnose "apt install failed with dpkg error"
```

closes cortexlinux/cortex-pro#2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI "diagnose" command supporting image, clipboard, and text inputs for troubleshooting; image-based diagnosis available.

* **Improvements**
  * Added image-diagnostic API with safer fallback handling to prevent recursion.
  * Reduced startup/log noise.

* **Bug Fixes**
  * Minor console formatting polish in the install flow.

* **Tests**
  * Tests added for image diagnosis behavior.

* **Chores**
  * Added Pillow dependency for image support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->