### PR TITLE
Validate langcain compatibility with python 3.13

### DIFF
--- a/docs/langchain_python_3_13.md
+++ b/docs/langchain_python_3_13.md
@@ -1,0 +1,35 @@
+# LangChain Python 3.13 Compatibility Validation
+
+## Environment
+- OS: Windows
+- Python: 3.13.11
+- Test Environment: Python virtual environment (venv)
+- Pytest used for validation
+
+## Packages Tested
+- langchain
+- langchain-core
+- langchain-community
+- langchain-anthropic
+
+## Validation Results
+
+### 1. Core Imports
+LangChain core modules import successfully under Python 3.13.
+
+### 2. Chain Execution
+Runnable pipelines using prompts and chained runnables execute correctly without errors.
+
+### 3. Streaming
+Streaming execution using `RunnableLambda.stream()` functions as expected.
+
+### 4. Memory Handling
+The legacy `langchain.memory` module is not available by default in the tested LangChain version.  
+Using `langchain_core.chat_history` is a working alternative.
+
+### Known Warning
+Pytest reports an `asyncio_mode` configuration warning originating from the existing repository configuration.  
+This warning predates Python 3.13 validation and does not affect LangChain functionality.
+
+## Conclusion
+LangChain is compatible with Python 3.13 for core usage, chain execution, streaming, and memory handling, with minor import-path adjustments for memory APIs.

--- a/tests/langchain_py313/test_basic_imports.py
+++ b/tests/langchain_py313/test_basic_imports.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytest.importorskip("langchain_core")
+
+import langchain
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+
+
+def test_langchain_imports():
+    assert langchain is not None

--- a/tests/langchain_py313/test_chain_execution.py
+++ b/tests/langchain_py313/test_chain_execution.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda
+
+
+def test_chain_execution():
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("human", "Hello {name}"),
+        ]
+    )
+
+    fake_llm = RunnableLambda(lambda _: "Hello User")
+
+    chain = prompt | fake_llm
+
+    result = chain.invoke({"name": "User"})
+
+    assert result == "Hello User"

--- a/tests/langchain_py313/test_memory.py
+++ b/tests/langchain_py313/test_memory.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.chat_history import InMemoryChatMessageHistory
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+def test_in_memory_chat_history():
+    history = InMemoryChatMessageHistory()
+
+    history.add_message(HumanMessage(content="Hello"))
+    history.add_message(AIMessage(content="Hi there"))
+
+    messages = history.messages
+
+    assert len(messages) == 2
+    assert messages[0].content == "Hello"
+    assert messages[1].content == "Hi there"

--- a/tests/langchain_py313/test_streaming.py
+++ b/tests/langchain_py313/test_streaming.py
@@ -1,0 +1,18 @@
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.runnables import RunnableLambda
+
+
+def test_streaming():
+    def streamer(_):
+        yield "Hello"
+        yield " "
+        yield "World"
+
+    runnable = RunnableLambda(streamer)
+
+    output = "".join(runnable.stream("input"))
+
+    assert output == "Hello World"


### PR DESCRIPTION
Fixes #274

## Summary
- Validated LangChain compatibility with Python 3.13
- Tested core imports, chain execution, streaming, and memory handling
- Added Python 3.13–specific validation tests
- Documented findings and workarounds

## Notes
- Memory APIs are available via `langchain_core.chat_history` in the tested LangChain version
- Existing pytest `asyncio_mode` warning predates this change and does not affect functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Python 3.13 compatibility guide covering validated features, environment used for testing, minor memory API import-path adjustments, and a non-impactful asyncio warning.

* **Tests**
  * Added validation tests for core imports, chain execution, streaming output, and in-memory chat message history under Python 3.13.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->