### PR TITLE
fix: resolve 'SystemInfo' object has no attribute 'get' error in cort…

### DIFF
--- a/cortex/demo.py
+++ b/cortex/demo.py
@@ -14,18 +14,18 @@ def run_demo() -> int:
 
     hw = detect_hardware()
 
-    print(f"✔ CPU: {hw.get('cpu', 'Unknown')}")
-    print(f"✔ RAM: {hw.get('memory_gb', 'Unknown')} GB")
+    print(f"✔ CPU: {hw.cpu.model}")
+    print(f"✔ RAM: {hw.memory.total_gb} GB")
 
-    gpu = hw.get("gpu")
-    if gpu:
-        print(f"✔ GPU: {gpu}")
+    gpu = hw.gpu
+    if gpu and len(gpu) > 0:
+        print(f"✔ GPU: {gpu[0].model}")
     else:
         print("⚠️ GPU: Not detected (CPU mode enabled)")
 
     # 2️⃣ Model Recommendations
     print("\n🤖 Model Recommendations:")
-    if gpu:
+    if gpu and len(gpu) > 0:
         print("• LLaMA-3-8B → Optimized for your GPU")
         print("• Mistral-7B → High performance inference")
     else:


### PR DESCRIPTION
Closes #353
**Summary**
Fixes a crash in cortex demo during the hardware scan step.

The demo was treating the SystemInfo dataclass returned by detect_hardware() as a dictionary and calling .get(), which caused the command to crash. This PR updates the demo to correctly access dataclass attributes.

**What was fixed**

- Replaced dictionary-style .get() access with direct dataclass attributes
- Fixed CPU detection using hw.cpu.model
- Fixed RAM detection using hw.memory.total_gb
- Fixed GPU handling using hw.gpu list with proper length checks

**Result**

- cortex demo now runs end-to-end without crashing
- Hardware information (CPU, RAM, GPU) is displayed correctly
- Demo completes with “Your system is READY for AI workloads”

**Environment**

- OS: Ubuntu 24.04
- Python: 3.10
- Command: cortex demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware detection accuracy for GPU and CPU-only systems
  * Enhanced model recommendations that intelligently adapt based on detected hardware
  * Better fallback support for CPU-only environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->