### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text storage of sensitive information

### DIFF
--- a/cortex/first_run_wizard.py
+++ b/cortex/first_run_wizard.py
@@ -759,21 +759,22 @@ Cortex is ready to use! Here are some things to try:
             return default
 
     def _save_env_var(self, name: str, value: str):
-        """Save environment variable to shell config."""
-        shell = os.environ.get("SHELL", "/bin/bash")
-        shell_name = os.path.basename(shell)
-        config_file = self._get_shell_config(shell_name)
+        """Set environment variable for current session and show how to persist it.
 
-        export_line = f'\nexport {name}="{value}"\n'  # nosec - intentional user config storage
+        To avoid storing sensitive data in clear text on disk, this method no longer
+        appends the value to shell configuration files. Instead, it sets the variable
+        for the current process and prints the export command so the user can add it
+        manually if they choose.
+        """
+        # Set for current session only
+        os.environ[name] = value
 
-        try:
-            with open(config_file, "a") as f:
-                f.write(export_line)
-
-            # Also set for current session
-            os.environ[name] = value
-        except Exception as e:
-            logger.warning(f"Could not save env var: {e}")
+        # Show user how to persist it without doing so automatically
+        export_line = f'export {name}="{value}"'
+        print(
+            f"\nTo persist this setting, add the following line to your shell config "
+            f"(e.g. ~/.bashrc or ~/.zshrc):\n  {export_line}\n"
+        )
 
 
 # Convenience functions


### PR DESCRIPTION
Potential fix for [https://github.com/cortexlinux/cortex/security/code-scanning/7](https://github.com/cortexlinux/cortex/security/code-scanning/7)

General approach: Avoid storing raw API keys directly in long‑lived, plain‑text shell configuration files. Either (1) don’t persist the key at all (use it only in‑memory), (2) store it in a dedicated config file with restricted permissions, or (3) if we must assist the user in adding it to their shell, print instructions rather than editing the rc file automatically.

Best fix with minimal functional change: Keep setting the environment variable for the current process (so the rest of the wizard behaves as before) but stop appending the raw secret to shell rc files. Instead, `_save_env_var` will set `os.environ[name] = value` and log a message telling the user to add the appropriate `export` line themselves if they want persistence. This avoids writing secrets to disk while still giving the user the information they need.

Concretely:

- Edit `FirstRunWizard._save_env_var` in `cortex/first_run_wizard.py`:
  - Remove the logic that computes the shell, finds the config file, builds `export_line`, and appends it to that file.
  - Keep setting `os.environ[name] = value`.
  - Optionally, log or print a short message indicating how the user can persist the variable manually (using the same `export` line), but without writing it automatically.
- No changes are needed to the call sites (`_setup_claude_api`, `_setup_openai_api`), because they already go through `_save_env_var`.

Needed elements:

- No new external libraries are necessary.
- We only modify `_save_env_var` and can rely on existing imports (`os`, `logger`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
