### PR TITLE
[cli] Fix incorrect command syntax in history error message

### DIFF
--- a/cortex/cli.py
+++ b/cortex/cli.py
@@ -471,7 +471,7 @@ class CortexCLI:
                             print(f"  Error: {error_msg}", file=sys.stderr)
                         if install_id:
                             print(f"\n📝 Installation recorded (ID: {install_id})")
-                            print(f"   View details: cortex history show {install_id}")
+                            print(f"   View details: cortex history {install_id}")
                         return 1
 
                     except (ValueError, OSError) as e:
@@ -530,7 +530,7 @@ class CortexCLI:
                         print(f"  Error: {result.error_message}", file=sys.stderr)
                     if install_id:
                         print(f"\n📝 Installation recorded (ID: {install_id})")
-                        print(f"   View details: cortex history show {install_id}")
+                        print(f"   View details: cortex history {install_id}")
                     return 1
             else:
                 print("\nTo execute these commands, run with --execute flag")


### PR DESCRIPTION
## Related Issue
Closes #379 

## Summary
Fix incorrect command syntax in error messages shown after failed installations. The message incorrectly suggested `cortex history show <id>` when the correct syntax is `cortex history <id>`.

<img width="1124" height="328" alt="image" src="https://github.com/user-attachments/assets/c31cad9b-fa94-4364-b9b2-9e4c7c748e31" />


## Checklist
- [x] Tests pass (`pytest tests/`)
- [ ] MVP label added if closing MVP issue
- [ ] Update "Cortex -h" (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified command syntax for viewing installation history. Users can now use `cortex history {install_id}` instead of `cortex history show {install_id}` to access installation details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->