### PR TITLE
feat: add Printer Setup Helper tool

### DIFF
--- a/scripts/printer_setup_helper.py
+++ b/scripts/printer_setup_helper.py
@@ -1,0 +1,17 @@
+import subprocess
+
+def setup_printer(name, connection):
+    """Automates printer setup using lpadmin."""
+    print(f"Adding printer {name} with connection {connection}...")
+    try:
+        subprocess.run(["sudo", "lpadmin", "-p", name, "-E", "-v", connection], check=True)
+        print(f"SUCCESS: Printer {name} is ready.")
+    except Exception as e:
+        print(f"ERROR: Failed to setup printer. {e}")
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 3:
+        print("Usage: printer_helper <name> <connection_url>")
+        sys.exit(1)
+    setup_printer(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
This script simplifies the process of adding and configuring printers on Linux using CUPS. Closes #451. /claim #451