### PR TITLE
chore: add jeremylongshore to CLA signers

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -203,6 +203,15 @@
       ],
       "signed_date": "2026-01-11",
       "cla_version": "1.0"
+    },
+    {
+      "name": "Jeremy Longshore",
+      "github_username": "jeremylongshore",
+      "emails": [
+        "jeremylongshore@gmail.com"
+      ],
+      "signed_date": "2026-01-11",
+      "cla_version": "1.0"
     }
   ],
   "corporations": {


### PR DESCRIPTION
## Summary
Adding myself to the CLA signers file to enable CLA checks on my PRs.

- GitHub username: `jeremylongshore`
- Email: `jeremylongshore@gmail.com`
- Signed date: 2026-01-11

## Related PRs
This unblocks CLA checks for:
- #557 (systemd service helper)
- #558 (tarball helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the list of contributors who have signed the Contributor License Agreement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->