### PR TITLE
chore(cla): add Doddi Sri Krishna Vamsi to signers

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "2026-01-03",
+  "last_updated": "2026-01-12",
   "individuals": [
     {
       "name": "Mike Morgan",
@@ -211,6 +211,15 @@
         "jeremylongshore@gmail.com"
       ],
       "signed_date": "2026-01-11",
+      "cla_version": "1.0"
+    },
+    {
+      "name": "Doddi Sri Krishna Vamsi",
+      "github_username": "srikrishnavansi",
+      "emails": [
+        "srikrishnavamsi1403@gmail.com"
+      ],
+      "signed_date": "2026-01-12",
       "cla_version": "1.0"
     }
   ],


### PR DESCRIPTION
Adding myself to the CLA signers list.

  ## CLA Signature Details
  - **Name:** Doddi Sri Krishna Vamsi
  - **GitHub Username:** srikrishnavansi
  - **Email:** srikrishnavamsi1403@gmail.com
  - **Date:** 2026-01-12

  I have read and agree to the [Contributor License Agreement](https://github.com/cortexlinux/cortex/blob/main/CLA.md).

  ## Related
  This CLA signature is required for PR #566 (AI-Powered Installation Tutor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor license agreement records with new signer information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->