### PR TITLE
ci(release): add automated build, GitHub release, and PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: build
+    needs: [build, release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     environment:


### PR DESCRIPTION
This PR introduces a fully automated release pipeline triggered on version tags.

The workflow:
- Builds source distributions and wheels
- Uploads artifacts for inspection
- Creates a GitHub Release with checksums
- Publishes the package to PyPI using trusted publishing (OIDC)


Closes #591 

## AI Disclosure
- [ ] No AI used
- [x] AI/IDE/Agents used

Used AI assistance for validating GitHub Actions workflow structure and release best practices.

## Checklist
- [x] PR title follows format: `type(scope): description` or `[scope] description`
- [x] Tests pass (`pytest tests/`)
- [ ] MVP label added if closing MVP issue
- [ ] Update "Cortex -h" (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow for Python packages triggered by version tags (vX.Y.Z).
  * Builds source and wheel distributions, generates SHA256 checksums, and bundles artifacts for release.
  * Creates GitHub Releases with uploaded distribution assets and marks prereleases for alpha/beta/rc tags.
  * Automatically publishes released artifacts to PyPI after release validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->