### PR TITLE
feat: WiFi/Bluetooth driver auto-matcher

### DIFF
--- a/cortex/cli.py
+++ b/cortex/cli.py
@@ -3041,6 +3041,21 @@ def main():
     update_subs.add_parser("backups", help="List available backups for rollback")
     # --------------------------
 
+    # WiFi/Bluetooth Driver Matcher
+    wifi_parser = subparsers.add_parser("wifi", help="WiFi/Bluetooth driver auto-matcher")
+    wifi_parser.add_argument(
+        "action",
+        nargs="?",
+        default="status",
+        choices=["status", "detect", "recommend", "install", "connectivity"],
+        help="Action to perform (default: status)",
+    )
+    wifi_parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose output",
+    )
+
     args = parser.parse_args()
 
     # The Guard: Check for empty commands before starting the CLI
@@ -3127,6 +3142,12 @@ def main():
             return 0 if activate_license(args.license_key) else 1
         elif args.command == "update":
             return cli.update(args)
+        elif args.command == "wifi":
+            from cortex.wifi_driver import run_wifi_driver
+            return run_wifi_driver(
+                action=getattr(args, "action", "status"),
+                verbose=getattr(args, "verbose", False),
+            )
         else:
             parser.print_help()
             return 1

--- a/cortex/wifi_driver.py
+++ b/cortex/wifi_driver.py
@@ -1,0 +1,606 @@
+"""
+WiFi/Bluetooth Driver Auto-Matcher
+
+Issue: #444 - WiFi/Bluetooth Driver Auto-Matcher
+
+Identifies wireless hardware, searches driver database,
+installs appropriate drivers, and validates connectivity.
+"""
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+
+
+class DeviceType(Enum):
+    """Type of wireless device."""
+
+    WIFI = "wifi"
+    BLUETOOTH = "bluetooth"
+    COMBO = "combo"  # Combined WiFi + Bluetooth
+
+
+class ConnectionType(Enum):
+    """Hardware connection type."""
+
+    PCI = "pci"
+    USB = "usb"
+    SDIO = "sdio"
+
+
+class DriverSource(Enum):
+    """Source of driver package."""
+
+    KERNEL = "kernel"  # Built into kernel
+    DKMS = "dkms"  # DKMS module
+    PACKAGE = "package"  # Distribution package
+    MANUAL = "manual"  # Manual compilation required
+
+
+@dataclass
+class WirelessDevice:
+    """Represents a detected wireless device."""
+
+    name: str
+    device_type: DeviceType
+    connection: ConnectionType
+    vendor_id: str = ""
+    device_id: str = ""
+    vendor: str = ""
+    driver_loaded: str = ""
+    is_working: bool = False
+
+
+@dataclass
+class DriverInfo:
+    """Information about a driver."""
+
+    name: str
+    package: str = ""
+    source: DriverSource = DriverSource.PACKAGE
+    git_url: str = ""
+    supported_ids: list = field(default_factory=list)
+    notes: str = ""
+
+
+# Driver database for common problematic chips
+DRIVER_DATABASE = {
+    # Realtek WiFi
+    "rtl8821ce": DriverInfo(
+        name="RTL8821CE",
+        package="rtl8821ce-dkms",
+        source=DriverSource.DKMS,
+        git_url="https://github.com/tomaspinho/rtl8821ce",
+        supported_ids=[("10ec", "c821"), ("10ec", "c82f")],
+        notes="Common in budget laptops",
+    ),
+    "rtl8822be": DriverInfo(
+        name="RTL8822BE",
+        package="rtw88-dkms",
+        source=DriverSource.DKMS,
+        supported_ids=[("10ec", "b822")],
+        notes="Uses rtw88 driver",
+    ),
+    "rtl8822ce": DriverInfo(
+        name="RTL8822CE",
+        package="rtw88-dkms",
+        source=DriverSource.DKMS,
+        supported_ids=[("10ec", "c822")],
+        notes="Uses rtw88 driver",
+    ),
+    "rtl8852ae": DriverInfo(
+        name="RTL8852AE",
+        package="rtw89-dkms",
+        source=DriverSource.DKMS,
+        git_url="https://github.com/lwfinger/rtw89",
+        supported_ids=[("10ec", "8852")],
+        notes="WiFi 6 chip",
+    ),
+    "rtl8852be": DriverInfo(
+        name="RTL8852BE",
+        package="rtw89-dkms",
+        source=DriverSource.DKMS,
+        git_url="https://github.com/lwfinger/rtw89",
+        supported_ids=[("10ec", "b852")],
+        notes="WiFi 6 chip",
+    ),
+    # Mediatek WiFi
+    "mt7921": DriverInfo(
+        name="MT7921",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        supported_ids=[("14c3", "7961")],
+        notes="Kernel 5.12+ required",
+    ),
+    "mt7922": DriverInfo(
+        name="MT7922",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        supported_ids=[("14c3", "0616")],
+        notes="Kernel 5.18+ required",
+    ),
+    # Intel WiFi
+    "iwlwifi": DriverInfo(
+        name="Intel Wireless",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        supported_ids=[("8086", "2723"), ("8086", "2725"), ("8086", "a0f0")],
+        notes="Standard kernel driver",
+    ),
+    # Broadcom
+    "bcm4350": DriverInfo(
+        name="Broadcom BCM4350",
+        package="broadcom-sta-dkms",
+        source=DriverSource.DKMS,
+        supported_ids=[("14e4", "43a3")],
+        notes="Proprietary driver",
+    ),
+    # Atheros
+    "ath11k": DriverInfo(
+        name="Atheros 11k",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        supported_ids=[("17cb", "1103")],
+        notes="WiFi 6 Qualcomm/Atheros",
+    ),
+}
+
+# Bluetooth drivers
+BLUETOOTH_DRIVERS = {
+    "btrtl": DriverInfo(
+        name="Realtek Bluetooth",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        notes="Realtek USB Bluetooth",
+    ),
+    "btmtk": DriverInfo(
+        name="Mediatek Bluetooth",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        notes="Mediatek USB Bluetooth",
+    ),
+    "btintel": DriverInfo(
+        name="Intel Bluetooth",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        notes="Intel USB Bluetooth",
+    ),
+    "btbcm": DriverInfo(
+        name="Broadcom Bluetooth",
+        package="linux-firmware",
+        source=DriverSource.KERNEL,
+        notes="Broadcom USB Bluetooth",
+    ),
+}
+
+
+class WirelessDriverMatcher:
+    """Matches wireless hardware to appropriate drivers."""
+
+    def __init__(self, verbose: bool = False):
+        """Initialize the driver matcher."""
+        self.verbose = verbose
+        self.devices: list[WirelessDevice] = []
+
+    def _run_command(
+        self, cmd: list[str], timeout: int = 30
+    ) -> tuple[int, str, str]:
+        """Run a command and return exit code, stdout, stderr."""
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return result.returncode, result.stdout, result.stderr
+        except subprocess.TimeoutExpired:
+            return 1, "", "Command timed out"
+        except FileNotFoundError:
+            return 1, "", f"Command not found: {cmd[0]}"
+        except Exception as e:
+            return 1, "", str(e)
+
+    def _detect_vendor(self, name: str) -> str:
+        """Detect vendor from device name."""
+        name_lower = name.lower()
+        vendors = {
+            "realtek": ["realtek", "rtl"],
+            "intel": ["intel", "wireless-ac", "wifi 6"],
+            "mediatek": ["mediatek", "mt7"],
+            "broadcom": ["broadcom", "bcm"],
+            "atheros": ["atheros", "qualcomm", "ath"],
+            "ralink": ["ralink", "rt28", "rt38"],
+        }
+        for vendor, patterns in vendors.items():
+            for pattern in patterns:
+                if pattern in name_lower:
+                    return vendor
+        return "unknown"
+
+    def detect_pci_devices(self) -> list[WirelessDevice]:
+        """Detect PCI wireless devices using lspci."""
+        devices = []
+
+        # Get network controllers
+        code, output, _ = self._run_command(["lspci", "-nn", "-D"])
+        if code != 0:
+            return devices
+
+        # Parse for network controllers
+        for line in output.splitlines():
+            if "network" in line.lower() or "wireless" in line.lower():
+                # Extract vendor:device ID
+                match = re.search(r"\[([0-9a-f]{4}):([0-9a-f]{4})\]", line.lower())
+                if match:
+                    vendor_id, device_id = match.groups()
+
+                    # Determine device type
+                    device_type = DeviceType.WIFI
+                    if "bluetooth" in line.lower():
+                        device_type = DeviceType.BLUETOOTH
+
+                    # Get driver info
+                    driver = ""
+                    pci_addr = line.split()[0] if line.split() else ""
+                    if pci_addr:
+                        _, drv_out, _ = self._run_command(
+                            ["lspci", "-k", "-s", pci_addr]
+                        )
+                        drv_match = re.search(
+                            r"Kernel driver in use:\s*(\S+)", drv_out
+                        )
+                        if drv_match:
+                            driver = drv_match.group(1)
+
+                    # Clean device name
+                    name = line.split(":", 2)[-1].strip() if ":" in line else line
+
+                    device = WirelessDevice(
+                        name=name,
+                        device_type=device_type,
+                        connection=ConnectionType.PCI,
+                        vendor_id=vendor_id,
+                        device_id=device_id,
+                        vendor=self._detect_vendor(name),
+                        driver_loaded=driver,
+                        is_working=bool(driver),
+                    )
+                    devices.append(device)
+
+        return devices
+
+    def detect_usb_devices(self) -> list[WirelessDevice]:
+        """Detect USB wireless devices using lsusb."""
+        devices = []
+
+        code, output, _ = self._run_command(["lsusb"])
+        if code != 0:
+            return devices
+
+        # Known USB wireless vendor IDs
+        wireless_vendors = {
+            "0bda": "realtek",
+            "0cf3": "atheros",
+            "0e8d": "mediatek",
+            "8087": "intel",
+            "0a5c": "broadcom",
+            "148f": "ralink",
+        }
+
+        for line in output.splitlines():
+            match = re.search(r"id\s+([0-9a-f]{4}):([0-9a-f]{4})", line.lower())
+            if match:
+                vendor_id, device_id = match.groups()
+                if vendor_id in wireless_vendors:
+                    # Determine if WiFi or Bluetooth
+                    device_type = DeviceType.WIFI
+                    if "bluetooth" in line.lower():
+                        device_type = DeviceType.BLUETOOTH
+
+                    name = line.split(":", 1)[-1].strip() if ":" in line else line
+
+                    device = WirelessDevice(
+                        name=name,
+                        device_type=device_type,
+                        connection=ConnectionType.USB,
+                        vendor_id=vendor_id,
+                        device_id=device_id,
+                        vendor=wireless_vendors[vendor_id],
+                    )
+                    devices.append(device)
+
+        return devices
+
+    def detect_all_devices(self) -> list[WirelessDevice]:
+        """Detect all wireless devices."""
+        self.devices = []
+        self.devices.extend(self.detect_pci_devices())
+        self.devices.extend(self.detect_usb_devices())
+        return self.devices
+
+    def find_driver(self, device: WirelessDevice) -> Optional[DriverInfo]:
+        """Find appropriate driver for a device."""
+        # Check by vendor:device ID
+        for driver_name, driver in DRIVER_DATABASE.items():
+            for vid, did in driver.supported_ids:
+                if device.vendor_id == vid and device.device_id == did:
+                    return driver
+
+        # Check Bluetooth drivers
+        if device.device_type == DeviceType.BLUETOOTH:
+            vendor_bt_map = {
+                "realtek": "btrtl",
+                "intel": "btintel",
+                "broadcom": "btbcm",
+                "mediatek": "btmtk",
+            }
+            if device.vendor in vendor_bt_map:
+                return BLUETOOTH_DRIVERS.get(vendor_bt_map[device.vendor])
+
+        return None
+
+    def check_connectivity(self) -> dict:
+        """Check WiFi and Bluetooth connectivity status."""
+        status = {
+            "wifi_interface": None,
+            "wifi_connected": False,
+            "wifi_ssid": None,
+            "bluetooth_available": False,
+            "bluetooth_powered": False,
+        }
+
+        # Check WiFi
+        code, output, _ = self._run_command(["ip", "link", "show"])
+        if code == 0:
+            for line in output.splitlines():
+                if "wl" in line and "state UP" in line:
+                    match = re.search(r"^\d+:\s+(\w+):", line)
+                    if match:
+                        status["wifi_interface"] = match.group(1)
+                        status["wifi_connected"] = True
+
+        # Get SSID if connected
+        if status["wifi_connected"]:
+            code, output, _ = self._run_command(["iwgetid", "-r"])
+            if code == 0 and output.strip():
+                status["wifi_ssid"] = output.strip()
+
+        # Check Bluetooth
+        code, output, _ = self._run_command(["bluetoothctl", "show"])
+        if code == 0:
+            status["bluetooth_available"] = True
+            if "Powered: yes" in output:
+                status["bluetooth_powered"] = True
+
+        return status
+
+    def get_install_commands(self, driver: DriverInfo) -> list[str]:
+        """Get commands to install a driver."""
+        commands = []
+
+        if driver.source == DriverSource.PACKAGE:
+            commands.append(f"sudo apt install -y {driver.package}")
+        elif driver.source == DriverSource.DKMS:
+            if driver.git_url:
+                commands.extend(
+                    [
+                        f"git clone {driver.git_url}",
+                        f"cd {driver.name.lower()} && sudo ./dkms-install.sh",
+                    ]
+                )
+            else:
+                commands.append(f"sudo apt install -y {driver.package}")
+        elif driver.source == DriverSource.KERNEL:
+            commands.append(f"sudo apt install -y {driver.package}")
+            commands.append("sudo update-initramfs -u")
+
+        return commands
+
+    def install_driver(self, driver: DriverInfo) -> tuple[bool, str]:
+        """Install a driver package."""
+        if driver.source == DriverSource.PACKAGE or driver.source == DriverSource.KERNEL:
+            code, _, stderr = self._run_command(
+                ["sudo", "apt", "install", "-y", driver.package],
+                timeout=300,
+            )
+            if code != 0:
+                return False, f"Failed to install {driver.package}: {stderr}"
+            return True, f"Installed {driver.package}"
+
+        elif driver.source == DriverSource.DKMS:
+            if driver.git_url:
+                return False, f"Manual installation required: {driver.git_url}"
+            else:
+                code, _, stderr = self._run_command(
+                    ["sudo", "apt", "install", "-y", driver.package],
+                    timeout=300,
+                )
+                if code != 0:
+                    return False, f"Failed to install {driver.package}: {stderr}"
+                return True, f"Installed DKMS module {driver.package}"
+
+        return False, "Unknown driver source"
+
+    def display_status(self):
+        """Display wireless device status."""
+        self.detect_all_devices()
+        connectivity = self.check_connectivity()
+
+        # Connectivity status
+        console.print(
+            Panel(
+                "[bold]Wireless Connectivity Status[/bold]",
+                style="cyan",
+            )
+        )
+
+        conn_table = Table(show_header=False, box=None)
+        conn_table.add_column("Item", style="cyan")
+        conn_table.add_column("Value")
+
+        wifi_status = "[green]Connected[/green]" if connectivity["wifi_connected"] else "[red]Not connected[/red]"
+        if connectivity["wifi_ssid"]:
+            wifi_status += f" ({connectivity['wifi_ssid']})"
+        conn_table.add_row("WiFi", wifi_status)
+
+        bt_status = "[green]Available[/green]" if connectivity["bluetooth_available"] else "[red]Not available[/red]"
+        if connectivity["bluetooth_powered"]:
+            bt_status += " (Powered)"
+        conn_table.add_row("Bluetooth", bt_status)
+
+        console.print(conn_table)
+        console.print()
+
+        # Devices table
+        console.print(
+            Panel(
+                "[bold]Detected Wireless Devices[/bold]",
+                style="cyan",
+            )
+        )
+
+        if not self.devices:
+            console.print("[yellow]No wireless devices detected[/yellow]")
+            return
+
+        table = Table()
+        table.add_column("Device", style="white")
+        table.add_column("Type", style="cyan")
+        table.add_column("Vendor", style="blue")
+        table.add_column("Driver", style="green")
+        table.add_column("Status", style="yellow")
+
+        for device in self.devices:
+            driver = self.find_driver(device)
+            driver_name = driver.name if driver else device.driver_loaded or "Unknown"
+
+            status = "[green]Working[/green]" if device.is_working else "[red]No driver[/red]"
+            if driver and not device.is_working:
+                status = "[yellow]Driver available[/yellow]"
+
+            # Truncate long names
+            name = device.name[:40] + "..." if len(device.name) > 40 else device.name
+
+            table.add_row(
+                name,
+                device.device_type.value,
+                device.vendor,
+                driver_name,
+                status,
+            )
+
+        console.print(table)
+
+    def display_recommendations(self):
+        """Display driver recommendations for problematic devices."""
+        self.detect_all_devices()
+
+        devices_needing_drivers = [d for d in self.devices if not d.is_working]
+
+        if not devices_needing_drivers:
+            console.print("[green]All wireless devices have working drivers[/green]")
+            return
+
+        console.print(
+            Panel(
+                "[bold]Driver Recommendations[/bold]",
+                style="yellow",
+            )
+        )
+
+        for device in devices_needing_drivers:
+            driver = self.find_driver(device)
+
+            if driver:
+                console.print(f"\n[bold]{device.name}[/bold]")
+                console.print(f"  Recommended driver: [cyan]{driver.name}[/cyan]")
+                console.print(f"  Package: [green]{driver.package}[/green]")
+                console.print(f"  Source: {driver.source.value}")
+                if driver.notes:
+                    console.print(f"  Notes: {driver.notes}")
+
+                console.print("\n  Install commands:")
+                for cmd in self.get_install_commands(driver):
+                    console.print(f"    [dim]$ {cmd}[/dim]")
+            else:
+                console.print(f"\n[bold]{device.name}[/bold]")
+                console.print("  [red]No known driver available[/red]")
+                console.print(f"  Vendor ID: {device.vendor_id}")
+                console.print(f"  Device ID: {device.device_id}")
+                console.print("  Try searching: linux-hardware.org or wikidevi.wi-cat.ru")
+
+
+def run_wifi_driver(
+    action: str = "status",
+    verbose: bool = False,
+) -> int:
+    """Run WiFi/Bluetooth driver matcher.
+
+    Args:
+        action: Action to perform (status, detect, recommend, install)
+        verbose: Enable verbose output
+
+    Returns:
+        Exit code (0 for success)
+    """
+    matcher = WirelessDriverMatcher(verbose=verbose)
+
+    if action == "status":
+        matcher.display_status()
+        return 0
+
+    elif action == "detect":
+        devices = matcher.detect_all_devices()
+        if devices:
+            console.print(f"[green]Found {len(devices)} wireless device(s)[/green]")
+            for d in devices:
+                console.print(f"  - {d.name} ({d.device_type.value})")
+        else:
+            console.print("[yellow]No wireless devices detected[/yellow]")
+        return 0
+
+    elif action == "recommend":
+        matcher.display_recommendations()
+        return 0
+
+    elif action == "install":
+        devices = matcher.detect_all_devices()
+        devices_needing_drivers = [d for d in devices if not d.is_working]
+
+        if not devices_needing_drivers:
+            console.print("[green]All devices have working drivers[/green]")
+            return 0
+
+        for device in devices_needing_drivers:
+            driver = matcher.find_driver(device)
+            if driver:
+                console.print(f"Installing driver for {device.name}...")
+                success, message = matcher.install_driver(driver)
+                if success:
+                    console.print(f"[green]{message}[/green]")
+                else:
+                    console.print(f"[red]{message}[/red]")
+
+        return 0
+
+    elif action == "connectivity":
+        status = matcher.check_connectivity()
+        console.print(f"WiFi: {'Connected' if status['wifi_connected'] else 'Not connected'}")
+        if status["wifi_ssid"]:
+            console.print(f"  SSID: {status['wifi_ssid']}")
+        console.print(f"Bluetooth: {'Available' if status['bluetooth_available'] else 'Not available'}")
+        return 0
+
+    else:
+        console.print(f"[red]Unknown action: {action}[/red]")
+        console.print("Available actions: status, detect, recommend, install, connectivity")
+        return 1

--- a/tests/test_wifi_driver.py
+++ b/tests/test_wifi_driver.py
@@ -1,0 +1,550 @@
+"""
+Tests for WiFi/Bluetooth Driver Auto-Matcher
+
+Issue: #444 - WiFi/Bluetooth Driver Auto-Matcher
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from cortex.wifi_driver import (
+    ConnectionType,
+    DeviceType,
+    DriverInfo,
+    DriverSource,
+    WirelessDevice,
+    WirelessDriverMatcher,
+    DRIVER_DATABASE,
+    BLUETOOTH_DRIVERS,
+    run_wifi_driver,
+)
+
+
+class TestDeviceType:
+    """Tests for DeviceType enum."""
+
+    def test_device_types(self):
+        """Test all device types are defined."""
+        assert DeviceType.WIFI.value == "wifi"
+        assert DeviceType.BLUETOOTH.value == "bluetooth"
+        assert DeviceType.COMBO.value == "combo"
+
+
+class TestConnectionType:
+    """Tests for ConnectionType enum."""
+
+    def test_connection_types(self):
+        """Test all connection types are defined."""
+        assert ConnectionType.PCI.value == "pci"
+        assert ConnectionType.USB.value == "usb"
+        assert ConnectionType.SDIO.value == "sdio"
+
+
+class TestDriverSource:
+    """Tests for DriverSource enum."""
+
+    def test_driver_sources(self):
+        """Test all driver sources are defined."""
+        assert DriverSource.KERNEL.value == "kernel"
+        assert DriverSource.DKMS.value == "dkms"
+        assert DriverSource.PACKAGE.value == "package"
+        assert DriverSource.MANUAL.value == "manual"
+
+
+class TestWirelessDevice:
+    """Tests for WirelessDevice dataclass."""
+
+    def test_default_values(self):
+        """Test default device values."""
+        device = WirelessDevice(
+            name="Test WiFi",
+            device_type=DeviceType.WIFI,
+            connection=ConnectionType.PCI,
+        )
+        assert device.name == "Test WiFi"
+        assert device.vendor_id == ""
+        assert device.is_working is False
+
+    def test_full_device(self):
+        """Test device with full values."""
+        device = WirelessDevice(
+            name="Intel Wireless",
+            device_type=DeviceType.WIFI,
+            connection=ConnectionType.PCI,
+            vendor_id="8086",
+            device_id="2723",
+            vendor="intel",
+            driver_loaded="iwlwifi",
+            is_working=True,
+        )
+        assert device.vendor == "intel"
+        assert device.is_working is True
+        assert device.driver_loaded == "iwlwifi"
+
+
+class TestDriverInfo:
+    """Tests for DriverInfo dataclass."""
+
+    def test_default_values(self):
+        """Test default driver values."""
+        driver = DriverInfo(name="Test Driver")
+        assert driver.package == ""
+        assert driver.source == DriverSource.PACKAGE
+        assert driver.supported_ids == []
+
+    def test_full_driver(self):
+        """Test driver with full values."""
+        driver = DriverInfo(
+            name="RTL8821CE",
+            package="rtl8821ce-dkms",
+            source=DriverSource.DKMS,
+            git_url="https://github.com/test/driver",
+            supported_ids=[("10ec", "c821")],
+            notes="Test notes",
+        )
+        assert driver.source == DriverSource.DKMS
+        assert len(driver.supported_ids) == 1
+
+
+class TestDriverDatabase:
+    """Tests for driver database constants."""
+
+    def test_realtek_drivers_defined(self):
+        """Test Realtek drivers are defined."""
+        assert "rtl8821ce" in DRIVER_DATABASE
+        assert "rtl8822ce" in DRIVER_DATABASE
+
+    def test_mediatek_drivers_defined(self):
+        """Test Mediatek drivers are defined."""
+        assert "mt7921" in DRIVER_DATABASE
+
+    def test_intel_drivers_defined(self):
+        """Test Intel drivers are defined."""
+        assert "iwlwifi" in DRIVER_DATABASE
+
+    def test_bluetooth_drivers_defined(self):
+        """Test Bluetooth drivers are defined."""
+        assert "btrtl" in BLUETOOTH_DRIVERS
+        assert "btintel" in BLUETOOTH_DRIVERS
+
+
+class TestWirelessDriverMatcher:
+    """Tests for WirelessDriverMatcher class."""
+
+    @pytest.fixture
+    def matcher(self):
+        """Create a matcher instance."""
+        return WirelessDriverMatcher(verbose=False)
+
+    def test_initialization(self, matcher):
+        """Test matcher initialization."""
+        assert matcher.verbose is False
+        assert matcher.devices == []
+
+    def test_detect_vendor_realtek(self, matcher):
+        """Test Realtek vendor detection."""
+        assert matcher._detect_vendor("Realtek RTL8821CE") == "realtek"
+        assert matcher._detect_vendor("RTL8852AE") == "realtek"
+
+    def test_detect_vendor_intel(self, matcher):
+        """Test Intel vendor detection."""
+        assert matcher._detect_vendor("Intel Wireless-AC 9560") == "intel"
+        assert matcher._detect_vendor("Intel WiFi 6 AX200") == "intel"
+
+    def test_detect_vendor_mediatek(self, matcher):
+        """Test Mediatek vendor detection."""
+        assert matcher._detect_vendor("Mediatek MT7921") == "mediatek"
+        assert matcher._detect_vendor("MT7922 WiFi") == "mediatek"
+
+    def test_detect_vendor_broadcom(self, matcher):
+        """Test Broadcom vendor detection."""
+        assert matcher._detect_vendor("Broadcom BCM4350") == "broadcom"
+
+    def test_detect_vendor_unknown(self, matcher):
+        """Test unknown vendor detection."""
+        assert matcher._detect_vendor("Random WiFi Card") == "unknown"
+
+
+class TestDetectPCIDevices:
+    """Tests for PCI device detection."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_detect_pci_devices_parses_lspci(self, matcher):
+        """Test lspci parsing for wireless devices."""
+        lspci_output = """00:00.0 Host bridge [0600]: Intel Corporation Device [8086:a700]
+02:00.0 Network controller [0280]: Intel Corporation Wi-Fi 6 AX201 [8086:a0f0]"""
+
+        lspci_driver = """02:00.0 Network controller: Intel Corporation Wi-Fi 6 AX201
+        Kernel driver in use: iwlwifi"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.side_effect = [
+                (0, lspci_output, ""),
+                (0, lspci_driver, ""),
+            ]
+
+            devices = matcher.detect_pci_devices()
+
+            assert len(devices) >= 1
+            wifi_devices = [d for d in devices if d.device_type == DeviceType.WIFI]
+            assert len(wifi_devices) >= 1
+
+    def test_detect_pci_devices_empty(self, matcher):
+        """Test when no wireless devices detected."""
+        lspci_output = """00:00.0 Host bridge [0600]: Intel Corporation Device [8086:a700]"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (0, lspci_output, "")
+
+            devices = matcher.detect_pci_devices()
+            assert devices == []
+
+    def test_detect_pci_command_failure(self, matcher):
+        """Test handling lspci failure."""
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (1, "", "command not found")
+
+            devices = matcher.detect_pci_devices()
+            assert devices == []
+
+
+class TestDetectUSBDevices:
+    """Tests for USB device detection."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_detect_usb_devices_parses_lsusb(self, matcher):
+        """Test lsusb parsing for wireless devices."""
+        lsusb_output = """Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 001 Device 003: ID 0bda:c820 Realtek Semiconductor Corp. RTL8821C"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (0, lsusb_output, "")
+
+            devices = matcher.detect_usb_devices()
+
+            assert len(devices) >= 1
+            realtek = [d for d in devices if d.vendor == "realtek"]
+            assert len(realtek) >= 1
+
+    def test_detect_usb_devices_bluetooth(self, matcher):
+        """Test USB Bluetooth detection."""
+        lsusb_output = """Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 001 Device 002: ID 8087:0a2b Intel Corp. Bluetooth wireless interface"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (0, lsusb_output, "")
+
+            devices = matcher.detect_usb_devices()
+
+            bt_devices = [d for d in devices if d.device_type == DeviceType.BLUETOOTH]
+            assert len(bt_devices) >= 1
+
+    def test_detect_usb_devices_empty(self, matcher):
+        """Test when no wireless USB devices."""
+        lsusb_output = """Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (0, lsusb_output, "")
+
+            devices = matcher.detect_usb_devices()
+            assert devices == []
+
+
+class TestFindDriver:
+    """Tests for driver matching."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_find_driver_by_id(self, matcher):
+        """Test finding driver by vendor:device ID."""
+        device = WirelessDevice(
+            name="Test Device",
+            device_type=DeviceType.WIFI,
+            connection=ConnectionType.PCI,
+            vendor_id="10ec",
+            device_id="c821",
+        )
+
+        driver = matcher.find_driver(device)
+        assert driver is not None
+        assert driver.name == "RTL8821CE"
+
+    def test_find_bluetooth_driver(self, matcher):
+        """Test finding Bluetooth driver."""
+        device = WirelessDevice(
+            name="Intel Bluetooth",
+            device_type=DeviceType.BLUETOOTH,
+            connection=ConnectionType.USB,
+            vendor="intel",
+        )
+
+        driver = matcher.find_driver(device)
+        assert driver is not None
+        assert "intel" in driver.name.lower()
+
+    def test_find_driver_not_found(self, matcher):
+        """Test when no driver found."""
+        device = WirelessDevice(
+            name="Unknown Device",
+            device_type=DeviceType.WIFI,
+            connection=ConnectionType.PCI,
+            vendor_id="ffff",
+            device_id="ffff",
+        )
+
+        driver = matcher.find_driver(device)
+        assert driver is None
+
+
+class TestCheckConnectivity:
+    """Tests for connectivity checking."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_check_wifi_connected(self, matcher):
+        """Test WiFi connected status."""
+        ip_output = """1: lo: <LOOPBACK,UP,LOWER_UP>
+2: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> state UP"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.side_effect = [
+                (0, ip_output, ""),
+                (0, "MyNetwork", ""),
+                (0, "", ""),
+            ]
+
+            status = matcher.check_connectivity()
+            assert status["wifi_connected"] is True
+
+    def test_check_wifi_not_connected(self, matcher):
+        """Test WiFi not connected."""
+        ip_output = """1: lo: <LOOPBACK,UP,LOWER_UP>
+2: wlan0: <BROADCAST,MULTICAST> state DOWN"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.side_effect = [
+                (0, ip_output, ""),
+                (1, "", ""),
+            ]
+
+            status = matcher.check_connectivity()
+            assert status["wifi_connected"] is False
+
+    def test_check_bluetooth_available(self, matcher):
+        """Test Bluetooth availability."""
+        bt_output = """Controller 00:11:22:33:44:55 (public)
+        Powered: yes"""
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.side_effect = [
+                (0, "1: wlan0: state DOWN", ""),
+                (0, bt_output, ""),
+            ]
+
+            status = matcher.check_connectivity()
+            assert status["bluetooth_available"] is True
+            assert status["bluetooth_powered"] is True
+
+
+class TestGetInstallCommands:
+    """Tests for install command generation."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_package_install_commands(self, matcher):
+        """Test package install commands."""
+        driver = DriverInfo(
+            name="Test",
+            package="test-driver",
+            source=DriverSource.PACKAGE,
+        )
+
+        commands = matcher.get_install_commands(driver)
+        assert "sudo apt install -y test-driver" in commands
+
+    def test_dkms_with_git_commands(self, matcher):
+        """Test DKMS with git repo commands."""
+        driver = DriverInfo(
+            name="rtl8821ce",
+            package="rtl8821ce-dkms",
+            source=DriverSource.DKMS,
+            git_url="https://github.com/test/rtl8821ce",
+        )
+
+        commands = matcher.get_install_commands(driver)
+        assert any("git clone" in cmd for cmd in commands)
+
+    def test_kernel_install_commands(self, matcher):
+        """Test kernel driver install commands."""
+        driver = DriverInfo(
+            name="Test",
+            package="linux-firmware",
+            source=DriverSource.KERNEL,
+        )
+
+        commands = matcher.get_install_commands(driver)
+        assert any("linux-firmware" in cmd for cmd in commands)
+        assert any("update-initramfs" in cmd for cmd in commands)
+
+
+class TestInstallDriver:
+    """Tests for driver installation."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_install_package_success(self, matcher):
+        """Test successful package installation."""
+        driver = DriverInfo(
+            name="Test",
+            package="linux-firmware",
+            source=DriverSource.PACKAGE,
+        )
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (0, "", "")
+
+            success, message = matcher.install_driver(driver)
+            assert success is True
+            assert "linux-firmware" in message
+
+    def test_install_package_failure(self, matcher):
+        """Test failed package installation."""
+        driver = DriverInfo(
+            name="Test",
+            package="nonexistent-package",
+            source=DriverSource.PACKAGE,
+        )
+
+        with patch.object(matcher, "_run_command") as mock_cmd:
+            mock_cmd.return_value = (1, "", "package not found")
+
+            success, message = matcher.install_driver(driver)
+            assert success is False
+
+    def test_install_dkms_with_git(self, matcher):
+        """Test DKMS with git requires manual install."""
+        driver = DriverInfo(
+            name="rtl8821ce",
+            package="rtl8821ce-dkms",
+            source=DriverSource.DKMS,
+            git_url="https://github.com/test/driver",
+        )
+
+        success, message = matcher.install_driver(driver)
+        assert success is False
+        assert "manual" in message.lower()
+
+
+class TestDisplayMethods:
+    """Tests for display methods."""
+
+    @pytest.fixture
+    def matcher(self):
+        return WirelessDriverMatcher()
+
+    def test_display_status(self, matcher, capsys):
+        """Test display_status runs without error."""
+        with patch.object(matcher, "detect_all_devices") as mock_detect:
+            with patch.object(matcher, "check_connectivity") as mock_conn:
+                mock_detect.return_value = []
+                mock_conn.return_value = {
+                    "wifi_interface": None,
+                    "wifi_connected": False,
+                    "wifi_ssid": None,
+                    "bluetooth_available": False,
+                    "bluetooth_powered": False,
+                }
+
+                matcher.display_status()
+                captured = capsys.readouterr()
+                assert "wifi" in captured.out.lower() or "wireless" in captured.out.lower()
+
+    def test_display_recommendations_no_issues(self, matcher, capsys):
+        """Test recommendations when all devices working."""
+        with patch.object(matcher, "detect_all_devices") as mock_detect:
+            mock_detect.return_value = [
+                WirelessDevice(
+                    name="Working WiFi",
+                    device_type=DeviceType.WIFI,
+                    connection=ConnectionType.PCI,
+                    is_working=True,
+                )
+            ]
+
+            matcher.display_recommendations()
+            captured = capsys.readouterr()
+            assert "working" in captured.out.lower()
+
+
+class TestRunWifiDriver:
+    """Tests for run_wifi_driver entry point."""
+
+    def test_run_status(self, capsys):
+        """Test running status action."""
+        with patch("cortex.wifi_driver.WirelessDriverMatcher") as MockMatcher:
+            mock_instance = MagicMock()
+            MockMatcher.return_value = mock_instance
+
+            result = run_wifi_driver("status")
+
+            mock_instance.display_status.assert_called_once()
+            assert result == 0
+
+    def test_run_detect(self, capsys):
+        """Test running detect action."""
+        with patch("cortex.wifi_driver.WirelessDriverMatcher") as MockMatcher:
+            mock_instance = MagicMock()
+            mock_instance.detect_all_devices.return_value = []
+            MockMatcher.return_value = mock_instance
+
+            result = run_wifi_driver("detect")
+
+            mock_instance.detect_all_devices.assert_called_once()
+            assert result == 0
+
+    def test_run_recommend(self, capsys):
+        """Test running recommend action."""
+        with patch("cortex.wifi_driver.WirelessDriverMatcher") as MockMatcher:
+            mock_instance = MagicMock()
+            MockMatcher.return_value = mock_instance
+
+            result = run_wifi_driver("recommend")
+
+            mock_instance.display_recommendations.assert_called_once()
+            assert result == 0
+
+    def test_run_unknown_action(self, capsys):
+        """Test unknown action."""
+        result = run_wifi_driver("unknown")
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "unknown" in captured.out.lower()
+
+    def test_run_connectivity(self, capsys):
+        """Test running connectivity check."""
+        with patch("cortex.wifi_driver.WirelessDriverMatcher") as MockMatcher:
+            mock_instance = MagicMock()
+            mock_instance.check_connectivity.return_value = {
+                "wifi_connected": True,
+                "wifi_ssid": "TestNetwork",
+                "bluetooth_available": True,
+            }
+            MockMatcher.return_value = mock_instance
+
+            result = run_wifi_driver("connectivity")
+            assert result == 0


### PR DESCRIPTION
## Summary

Implements #444 - WiFi/Bluetooth Driver Auto-Matcher for problematic wireless chips.

### Features
- **Hardware Detection**: PCI devices via lspci, USB devices via lsusb
- **Vendor Recognition**: Realtek, Intel, Mediatek, Broadcom, Atheros, Ralink
- **Driver Database**: Pre-configured for common problematic chips:
  - RTL8821CE, RTL8822CE, RTL8852AE/BE (Realtek)
  - MT7921, MT7922 (Mediatek)
  - Intel AX series
  - BCM4350 (Broadcom)
- **Install Automation**: Package, DKMS, and kernel driver installation
- **Connectivity Check**: WiFi and Bluetooth status verification

### Commands
```bash
cortex wifi status          # Show devices and connectivity
cortex wifi detect          # Detect wireless hardware
cortex wifi recommend       # Show driver recommendations
cortex wifi install         # Install missing drivers
cortex wifi connectivity    # Check connection status
```

### Testing
- 42 tests with comprehensive mocking
- All edge cases covered (missing tools, unknown hardware)

Fixes #444