### PR TITLE
feat(ci): add stale PR management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: 'Stale PR Management'
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PR settings: warn at 7 days, close at 14 days total
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+
+          stale-pr-label: 'state: inactive'
+
+          stale-pr-message: |
+            Action required: PR inactive for 7 days.
+            Status update or closure in 7 days.
+
+          close-pr-message: |
+            PR closed after 14 days of inactivity.
+
+          # Issue settings: disable for issues (only handle PRs)
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Exempt draft PRs and certain labels
+          exempt-draft-pr: true
+          exempt-pr-labels: 'work-in-progress,do-not-close'
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds automated stale PR management using `actions/stale`
- Warns contributors after 7 days of inactivity with `state: inactive` label
- Auto-closes PRs after 14 days total inactivity
- Exempts draft PRs and `work-in-progress`/`do-not-close` labels

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Monitor first run at midnight UTC
- [ ] Confirm labels and messages appear correctly on inactive PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented an automated stale pull request management system. Pull requests remaining inactive for 7 days will be automatically marked as stale, while those inactive for 14 days or longer will be automatically closed. Draft pull requests and those with specific exemption labels remain completely unaffected by this new automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->