### PR TITLE
fix: add autofix-ci bot to CLA ignore list and fix lint error

### DIFF
--- a/.github/scripts/cla_check.py
+++ b/.github/scripts/cla_check.py
@@ -337,6 +337,7 @@ def main():
 
     # Allowlist for bots
     bot_patterns = [
+        "autofix-ci",
         "dependabot",
         "github-actions",
         "renovate",


### PR DESCRIPTION
## Summary
- Add `autofix-ci[bot]` to the CLA verification bot allowlist in `.github/scripts/cla_check.py`
- Fix import sorting in `tests/test_licensing.py` to resolve ruff I001 lint error

## Test plan
- [ ] Verify CLA check passes for PRs from autofix-ci[bot]
- [ ] Verify `ruff check tests/test_licensing.py` passes without I001 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Licensing module public API expanded to include license activation, feature availability verification, license information retrieval, tier checks, and upgrade guidance.

* **Tests**
  * Updated licensing tests to validate newly exposed public API functionality.

* **Chores**
  * Updated bot detection patterns in CI workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->