### PR TITLE
chore: update SPDX headers from Apache-2.0 to BUSL-1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Cortex Linux is an AI-native package manager for Debian/Ubuntu that understands natural language commands. It wraps `apt` with LLM intelligence to parse requests, detect hardware, resolve dependencies, and execute installations safely.
 
 **Repository**: https://github.com/cortexlinux/cortex
-**License**: Apache 2.0
+**License**: BUSL-1.1 (Business Source License 1.1)
 **Primary Language**: Python 3.10+
 
 ## Quick Start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Infrastructure
 - GitHub Actions CI/CD pipeline
 - Unit test suite with pytest
-- Apache 2.0 License
+- BUSL-1.1 License (Business Source License 1.1)
 - Discord community integration
 - Bounty program for contributions
 

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 ## License
 
-Apache 2.0 - See [LICENSE](LICENSE) for details.
+BUSL-1.1 (Business Source License 1.1) - Free for personal use on 1 system. See [LICENSE](LICENSE) for details.
 
 ---
 

--- a/cortex/kernel_features/README.md
+++ b/cortex/kernel_features/README.md
@@ -172,4 +172,4 @@ ls -la /var/lib/cortex/models/
 
 ## License
 
-Apache 2.0 - See LICENSE file
+BUSL-1.1 - See LICENSE file

--- a/cortex/parallel_llm.py
+++ b/cortex/parallel_llm.py
@@ -11,7 +11,7 @@ Use cases:
 - Concurrent hardware config checks
 
 Author: Cortex Linux Team
-License: Apache 2.0
+SPDX-License-Identifier: BUSL-1.1
 """
 
 import asyncio

--- a/cortex/utils/db_pool.py
+++ b/cortex/utils/db_pool.py
@@ -5,7 +5,7 @@ Provides connection pooling to prevent database lock contention
 and enable safe concurrent access in Python 3.14 free-threading mode.
 
 Author: Cortex Linux Team
-License: Apache 2.0
+SPDX-License-Identifier: BUSL-1.1
 """
 
 import queue

--- a/docs/ASSESSMENT.md
+++ b/docs/ASSESSMENT.md
@@ -158,10 +158,9 @@ history.db
 
 ### 3.4 License Clarification Needed
 
-- LICENSE file is Apache 2.0
-- README mentions "MIT License" in some contexts
-- `llm_router.py` header says "Modified MIT License"
-- **Action:** Standardize license references
+- LICENSE file is BUSL-1.1 (Business Source License 1.1)
+- Converts to Apache 2.0 on January 15, 2030
+- **Action:** All file headers standardized to SPDX-License-Identifier: BUSL-1.1
 
 ---
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -12,7 +12,7 @@ A: MVP is 95% complete (November 2025). Demo-ready, production release coming so
 A: Ubuntu 24.04 LTS currently. Other Debian-based distros coming soon.
 
 **Q: Is it free?**
-A: Community edition is free and open source (Apache 2.0). Enterprise subscriptions available.
+A: Free for personal use on 1 system (BUSL-1.1 license). Commercial use requires a subscription. See https://cortexlinux.com/pricing
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cortex-linux"
 version = "0.1.0"
 description = "AI-powered package manager for Debian/Ubuntu that understands natural language"
 readme = "README.md"
-license = "Apache-2.0"
+license = "BUSL-1.1"
 authors = [
     {name = "Cortex Linux", email = "mike@cortexlinux.com"}
 ]

--- a/scripts/setup_ollama.py
+++ b/scripts/setup_ollama.py
@@ -17,7 +17,7 @@ Usage:
     python scripts/setup_ollama.py --skip-test       # Skip model testing
 
 Author: Cortex Linux Team
-License: Apache 2.0
+SPDX-License-Identifier: BUSL-1.1
 """
 
 import argparse

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -6,7 +6,7 @@ Run with:
     PYTHON_GIL=0 python3.14t -m pytest tests/test_thread_safety.py -v  # Without GIL
 
 Author: Cortex Linux Team
-License: Apache 2.0
+SPDX-License-Identifier: BUSL-1.1
 """
 
 import concurrent.futures


### PR DESCRIPTION
## Summary

Updates all SPDX license headers and references from Apache-2.0 to BUSL-1.1 to match the LICENSE file.

## Files Updated

| File | Change |
|------|--------|
| `pyproject.toml` | `license = "BUSL-1.1"` |
| `README.md` | License section updated |
| `AGENTS.md` | License reference updated |
| `CHANGELOG.md` | License reference updated |
| `cortex/parallel_llm.py` | SPDX header added |
| `cortex/utils/db_pool.py` | SPDX header added |
| `cortex/kernel_features/README.md` | License reference updated |
| `scripts/setup_ollama.py` | SPDX header added |
| `tests/test_thread_safety.py` | SPDX header added |
| `docs/ASSESSMENT.md` | License documentation updated |
| `docs/guides/FAQ.md` | License FAQ updated |

## Verification

```bash
grep -ri "Apache-2.0" --include="*.py" --include="*.md" --include="*.toml"
# Only remaining reference is Change Date documentation (correct)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project license from Apache 2.0 to BUSL-1.1 (Business Source License 1.1) across the codebase and metadata.
  * Clarified licensing terms: free for personal use on one system; commercial use requires a subscription.
  * License scheduled to convert to Apache 2.0 on January 15, 2030.
* **Documentation**
  * Updated README, changelog, FAQ, and related docs to reflect the new license and usage/pricing notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->