### PR TITLE
fix: add permissions to release workflow build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
       - name: Install build tools
         run: pip install build
-      
+
       - name: Build package
         run: python -m build
-      
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -40,6 +42,6 @@ jobs:
         with:
           name: dist
           path: dist/
-      
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to the `build` job in the release workflow
- Resolves CodeQL security alert #19 about missing workflow permissions
- Follows the principle of least privilege by limiting GITHUB_TOKEN scope

## Test plan
- [ ] Verify the workflow syntax is valid
- [ ] Confirm the release workflow still triggers correctly on release events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved build reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->