### PR TITLE
feat(daemon): System Monitoring and Persistent Alert Management

### DIFF
--- a/daemon/include/cortexd/alerts/alert_manager.h
+++ b/daemon/include/cortexd/alerts/alert_manager.h
@@ -93,6 +93,9 @@ public:
     /**
      * @brief Construct alert manager
      * @param db_path Path to SQLite database
+     * 
+     * Default path is /var/lib/cortex/alerts.db (requires root).
+     * If root access is unavailable, automatically falls back to ~/.cortex/alerts.db
      */
     explicit AlertManager(const std::string& db_path = "/var/lib/cortex/alerts.db");
     

--- a/daemon/include/cortexd/core/daemon.h
+++ b/daemon/include/cortexd/core/daemon.h
@@ -134,6 +134,7 @@ class IPCServer;
      mutable std::shared_mutex services_mutex_;  // Protect services_ vector access
      std::atomic<bool> running_{false};
      std::atomic<bool> shutdown_requested_{false};
+     mutable std::mutex start_time_mutex_;  // Protect start_time_ access
      std::chrono::steady_clock::time_point start_time_;
      
      /**

--- a/daemon/include/cortexd/ipc/server.h
+++ b/daemon/include/cortexd/ipc/server.h
@@ -93,6 +93,7 @@ private:
  private:
      std::string socket_path_;
      int server_fd_ = -1;
+     mutable std::mutex server_fd_mutex_;  // Protect server_fd_ access
      std::atomic<bool> running_{false};
      std::unique_ptr<std::thread> accept_thread_;
      

--- a/daemon/src/alerts/alert_manager.cpp
+++ b/daemon/src/alerts/alert_manager.cpp
@@ -648,6 +648,9 @@ std::vector<Alert> AlertManager::get_alerts(const AlertFilter& filter) {
     
     select_sql += " ORDER BY timestamp DESC";
     
+    // Protect database access with mutex (SQLite connections need protection for concurrent operations)
+    std::lock_guard<std::mutex> lock(stmt_mutex_);
+    
     sqlite3_stmt* stmt;
     int rc = sqlite3_prepare_v2(db, select_sql.c_str(), -1, &stmt, nullptr);
     
@@ -719,6 +722,7 @@ std::vector<Alert> AlertManager::get_alerts(const AlertFilter& filter) {
     }
     
     sqlite3_finalize(stmt);
+    // Lock released here when lock_guard goes out of scope
     return alerts;
 }
 


### PR DESCRIPTION
## Related Issue
Closes #651 
Part 2/3 of Issue #427 

## Summary
Introduces comprehensive system health monitoring and persistent alert management capabilities to the cortex daemon. The implementation provides real-time monitoring of system resources (CPU, memory, disk, services) with configurable thresholds and SQLite-based alert persistence.

## AI Disclosure
<!-- Please indicate if you used AI tools during development -->
- [ ] No AI used
- [x] AI/IDE/Agents used (please describe below)

Used Cursor to debug and make optimizations in the daemon.

## Features

### Alert Management
- **Persistent Storage**: SQLite database for alert persistence across daemon restarts
- **Alert Lifecycle**: Support for ACTIVE, ACKNOWLEDGED, and DISMISSED states
- **Severity Levels**: INFO, WARNING, ERROR, CRITICAL
- **Categories**: CPU, MEMORY, DISK, APT, CVE, SERVICE, SYSTEM
- **Thread-Safe Operations**: Mutex-protected SQLite prepared statements
- **Performance Optimizations**: 
  - In-memory atomic counters for O(1) alert counts
  - Prepared statement caching
  - WAL mode for better concurrency
- **Query Filtering**: Filter alerts by severity, category, status, and source
- **Bulk Operations**: Acknowledge all alerts at once

### System Monitoring
- **Resource Monitoring**: 
  - CPU usage percentage (calculated from `/proc/stat`)
  - Memory usage (total, used, available from `/proc/meminfo`)
  - Disk usage (root filesystem via `statvfs`)
  - System uptime (from `/proc/uptime`)
  - Failed systemd services count (via D-Bus)
- **Threshold-Based Alerts**: Automatic alert generation when thresholds are exceeded
- **Configurable Thresholds**: Warning and critical levels for CPU, memory, and disk
- **Performance Optimizations**:
  - `/proc` file caching (1-second TTL) to reduce I/O overhead
  - Persistent systemd D-Bus connection reuse
  - Alert deduplication using hash set (O(1) lookup)
- **Service Integration**: Implements `Service` interface for daemon lifecycle management

### IPC Integration
- **New Endpoints**:
  - `health` - Get current system health metrics and thresholds
  - `alerts` / `alerts.get` - Query alerts with optional filtering
  - `alerts.ack` - Acknowledge alerts (single UUID or all)
  - `alerts.dismiss` - Dismiss all or a specific alert
- **Response Format**: JSON with structured data and error handling

### Dependencies
- **SQLite3**: Alert persistence
- **UUID library**: Alert UUID generation

## Testing

- **Unit Tests**: Comprehensive test suite for `AlertManager` covering:
  - Alert creation and retrieval
  - Filtering by severity, category, status
  - Acknowledge and dismiss operations
  - Alert counts
  - Database persistence

## Checklist
- [x] PR title follows format: `type(scope): description` or `[scope] description`
- [ ] Tests pass (`pytest tests/`)
- [ ] MVP label added if closing MVP issue
- [x] Update "Cortex -h" (if needed)

## Demo of new features

[Screencast from 2026-01-21 16-48-31.webm](https://github.com/user-attachments/assets/5d6bd314-3844-4481-ad5c-145443889326)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System monitoring: real-time CPU/memory/disk usage, uptime and failed-service checks, configurable thresholds and live reloads.
  * Persistent alerting: create/list/filter alerts by severity/category, acknowledge-all, dismiss individual or all alerts.
  * CLI: new daemon health and daemon alerts commands with filtering and acknowledge/dismiss options.

* **Documentation**
  * README/daemon docs and Quick Start updated with health/alerts examples and config.

* **Chores**
  * Installer may create missing daemon config; build now uses SQLite-backed alert storage.

* **Tests**
  * New unit and integration tests for monitoring and alert manager.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->