### PR TITLE
fix(sandbox): Resolve SonarCloud BLOCKER - field naming conflict

### DIFF
--- a/cortex/sandbox/docker_sandbox.py
+++ b/cortex/sandbox/docker_sandbox.py
@@ -179,7 +179,7 @@ class DockerSandbox:
             image: Default Docker image to use. Defaults to ubuntu:22.04
         """
         self.data_dir = data_dir or Path.home() / ".cortex" / "sandboxes"
-        self.default_image = image or self.DEFAULT_IMAGE
+        self.base_image = image or self.DEFAULT_IMAGE
         self._docker_path: str | None = None
 
         # Ensure data directory exists
@@ -349,7 +349,7 @@ class DockerSandbox:
             raise SandboxAlreadyExistsError(f"Sandbox '{name}' already exists")
 
         container_name = self._get_container_name(name)
-        image = image or self.default_image
+        image = image or self.base_image
 
         try:
             # Pull image if needed


### PR DESCRIPTION
## Summary
- Renamed instance attribute `default_image` to `base_image` in `DockerSandbox` class to avoid confusion with the `DEFAULT_IMAGE` class constant
- Resolves SonarCloud BLOCKER issue S1845: "Rename this field 'default_image' to prevent any misunderstanding/clash with field 'DEFAULT_IMAGE'"

## Changes
- `sandbox/docker_sandbox.py`: Renamed `self.default_image` → `self.base_image` (2 occurrences)

## SonarCloud Analysis
The 10 BLOCKER issues were analyzed:
- **9 in cli.py**: False positives - methods intentionally return same value (CLI exit codes: 0=success, 1=error)
- **1 in docker_sandbox.py**: Real issue - field naming conflict (this PR)

See Issue #674 for full analysis.

## Test plan
- [x] Syntax check passed
- [x] All references to `default_image` updated to `base_image`
- [ ] Full test suite (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to Docker sandbox implementation for better code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->