### PR TITLE
docs: Add SPDX license identifier for BSL 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: BUSL-1.1
+
 # Business Source License 1.1
 
 ## Parameters


### PR DESCRIPTION
## Problem
GitHub shows **"Other"** in the license badge because BSL 1.1 isn't in their SPDX database. This looks unprofessional to investors and contributors.

## Solution
Added `SPDX-License-Identifier: BUSL-1.1` header to the LICENSE file.

## Validation
- License file renders correctly
- SPDX/SBOM tooling can detect license type automatically