### PR TITLE
🏷️ Rebrand: Replace 'Cortex' with 'CX Linux'

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -7,7 +7,7 @@
       "github_username": "mikejmorgan-ai",
       "emails": [
         "mike@aiventureholdings.com",
-        "mike@cortexlinux.com",
+        "mike@cxlinux.com",
         "allbots@llents.io",
         "allbots@allbots.io"
       ],
@@ -23,7 +23,7 @@
       "cla_version": "1.0",
       "domains": [
         "aiventureholdings.com",
-        "cortexlinux.com"
+        "cxlinux.com"
       ],
       "github_usernames": [
         "mikejmorgan-ai"

--- a/cx/ENTERPRISE_SECURITY.md
+++ b/cx/ENTERPRISE_SECURITY.md
@@ -202,9 +202,9 @@ pip install cryptography>=41.0.0 rich>=13.0.0 psutil>=5.8.0
 # Automatic setup on first run
 manager = SystemAlertManager()
 # Creates:
-# - ~/.cortex/alerts.db (secure permissions)
-# - ~/.cortex/alert_encryption.key (secure permissions)
-# - ~/.cortex/alert_manager.log (audit log)
+# - ~/.cx/alerts.db (secure permissions)
+# - ~/.cx/alert_encryption.key (secure permissions)
+# - ~/.cx/alert_manager.log (audit log)
 ```
 
 ## 🧪 Testing
@@ -213,7 +213,7 @@ manager = SystemAlertManager()
 
 ```bash
 # Run comprehensive security tests
-cd ~/cortex
+cd ~/cx
 python3 -m pytest tests/test_system_alert_manager_enterprise.py -v
 
 # Test categories:

--- a/docs/PROJECT_SCOPE.md
+++ b/docs/PROJECT_SCOPE.md
@@ -17,8 +17,8 @@ CX Terminal is an **AI-native terminal emulator** built on WezTerm, specifically
 
 CX Terminal is **not** the "Cortex" system administration CLI tool. The following components are **not part of this repository**:
 
-- `cortex` command-line tool
-- `cortex wizard`, `cortex config`, `cortex install` commands
+- `cx` command-line tool
+- `cx wizard`, `cx config`, `cx install` commands
 - Python-based system administration scripts
 - Docker sandbox management
 - Package installation automation
@@ -56,12 +56,12 @@ GitHub issues should relate to:
 - Documentation updates
 - WezTerm integration bugs
 
-Issues referencing "cortex" CLI commands, Python files, or system administration features likely belong to a different repository or are outdated from a previous project iteration.
+Issues referencing "cx" CLI commands, Python files, or system administration features likely belong to a different repository or are outdated from a previous project iteration.
 
 ## Related Projects
 
 If you're looking for CX Linux system administration tools, they may be located in:
-- A separate `cortex` repository
+- A separate `cx` repository
 - The main CX Linux distribution repository
 - Integrated into the `cx-daemon` service
 

--- a/scripts/resolve_issue_mismatch.md
+++ b/scripts/resolve_issue_mismatch.md
@@ -7,15 +7,15 @@ After analyzing the open issues in cxlinux-ai/cx, there's a clear mismatch betwe
 ## Issues to Close with Explanation
 
 ### Security Issues (Not Applicable)
-- **#671**: References `cortex/do_runner/diagnosis.py` - file doesn't exist in terminal emulator
+- **#671**: References `cx/do_runner/diagnosis.py` - file doesn't exist in terminal emulator
 - **#674**: References `cli.py` and `docker_sandbox.py` - files don't exist in terminal emulator
 
 ### CLI/System Admin Issues (Not Applicable)
-- **#547**: API key reconfiguration wizard for "cortex wizard" - not part of terminal emulator
-- **#371**: Offline mode export for "CORTEX_PROVIDER" - not part of terminal emulator
-- **#267**: Tiered approval modes for "cortex config" - not part of terminal emulator
-- **#51**: Real-time system health monitor for "cortex monitor" - not part of terminal emulator
-- **#445**: Network config validator for "cortex" tool - not part of terminal emulator
+- **#547**: API key reconfiguration wizard for "cx wizard" - not part of terminal emulator
+- **#371**: Offline mode export for "CX_PROVIDER" - not part of terminal emulator
+- **#267**: Tiered approval modes for "cx config" - not part of terminal emulator
+- **#51**: Real-time system health monitor for "cx monitor" - not part of terminal emulator
+- **#445**: Network config validator for "cx" tool - not part of terminal emulator
 
 ### Documentation Issue (Needs Adaptation)
 - **#619**: BSL license documentation - relevant but needs adaptation for CX Terminal context
@@ -40,7 +40,7 @@ If system administration features are desired in the terminal:
 ```
 This issue references the "Cortex" CLI system administration tool, but this repository contains CX Terminal - a Rust-based terminal emulator built on WezTerm.
 
-The files/commands referenced in this issue (cortex wizard, cli.py, etc.) do not exist in the current codebase.
+The files/commands referenced in this issue (cx wizard, cli.py, etc.) do not exist in the current codebase.
 
 See docs/PROJECT_SCOPE.md for clarification of what CX Terminal includes.
 


### PR DESCRIPTION
## Summary
Replace all 'Cortex' references with 'CX Linux' to address trademark concerns.

## Changes
- CLI commands: cortex → cx
- Paths: /etc/cortex/ → /etc/cx/
- Environment variables: CORTEX_* → CX_*

## Notes
Historical references in documentation kept for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guides and security documentation with revised file path references.

* **Chores**
  * Updated configuration and issue tracking files with product naming updates across multiple reference points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->