### PR TITLE
feat(hrm): Add optional HRM AI agent management commands

### DIFF
--- a/wezterm/Cargo.toml
+++ b/wezterm/Cargo.toml
@@ -45,11 +45,23 @@ wezterm-client.workspace = true
 wezterm-gui-subcommands.workspace = true
 wezterm-term.workspace = true
 
+<<<<<<< ours
 # CX Security dependencies
 rusqlite = { workspace = true, features = ["bundled"] }
 ureq = { version = "2.9", features = ["json"] }
 uuid = { version = "1.6", features = ["v4"] }
 dirs = "5.0"
+=======
+# HRM AI - Optional premium agent management (enable with --features hrm)
+hrm-ai = { git = "https://github.com/mikejmorgan-ai/hrm-ai-standalone.git", optional = true }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres"], optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+uuid = { version = "1.6", features = ["v4"], optional = true }
+
+[features]
+default = []
+hrm = ["dep:hrm-ai", "dep:sqlx", "dep:tokio", "dep:uuid"]
+>>>>>>> theirs
 
 [target."cfg(unix)".dependencies]
 termios.workspace = true

--- a/wezterm/src/cli/fire.rs
+++ b/wezterm/src/cli/fire.rs
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 CX Linux
+ * Licensed under the Business Source License 1.1
+ * You may not use this file except in compliance with the License.
+ */
+
+//! HRM AI Agent Termination Command
+//!
+//! Safely terminates AI agents with confirmation and audit logging.
+//! This module is only available when the `hrm` feature is enabled.
+//!
+//! # Example
+//! ```bash
+//! # Terminate an agent by ID
+//! cx fire abc123-def456
+//!
+//! # Force termination (skip confirmation)
+//! cx fire abc123-def456 --force
+//!
+//! # Terminate with reason
+//! cx fire abc123-def456 --reason "Migrating to new server"
+//! ```
+
+use anyhow::Result;
+use clap::Parser;
+
+#[cfg(feature = "hrm")]
+use hrm_ai::{
+    database::AgentRepository,
+    fire::{AgentTerminationService, TerminationConfig},
+    theme::SovereignTheme,
+};
+
+/// Terminate (fire) an AI agent
+#[derive(Debug, Parser, Clone)]
+pub struct FireCommand {
+    /// Agent ID to terminate
+    pub agent_id: String,
+
+    /// Skip confirmation prompt (dangerous)
+    #[arg(long, short = 'f')]
+    pub force: bool,
+
+    /// Reason for termination (for audit log)
+    #[arg(long, short = 'r')]
+    pub reason: Option<String>,
+
+    /// Graceful shutdown timeout in seconds
+    #[arg(long, default_value = "30")]
+    pub timeout: u64,
+
+    /// Output format: table, json
+    #[arg(long, default_value = "table")]
+    pub format: String,
+}
+
+impl FireCommand {
+    pub fn run(self) -> Result<()> {
+        #[cfg(feature = "hrm")]
+        {
+            run_fire_with_hrm(self)
+        }
+
+        #[cfg(not(feature = "hrm"))]
+        {
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            println!("  🔒 HRM AI Premium Feature");
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            println!();
+            println!("  The 'fire' command requires the HRM AI premium module.");
+            println!();
+            println!("  To enable HRM AI capabilities, rebuild with:");
+            println!("    cargo build --features hrm");
+            println!();
+            println!("  HRM AI Features:");
+            println!("    • cx hire <agent-type>  - Deploy AI agents");
+            println!("    • cx fire <agent-id>    - Terminate agents");
+            println!("    • PostgreSQL integration for fleet management");
+            println!("    • Enterprise compliance automation");
+            println!();
+            println!("  License: BSL 1.1 (Business Source License)");
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "hrm")]
+fn run_fire_with_hrm(cmd: FireCommand) -> Result<()> {
+    use std::time::Duration;
+    use tokio::runtime::Runtime;
+
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let theme = SovereignTheme::new();
+
+        // Print header
+        theme.print_header("CX Linux Agent Termination");
+
+        // Get database URL from environment
+        let db_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/cx_agents".to_string());
+
+        // Create repository to fetch agent info
+        let repo = AgentRepository::new(&db_url).await?;
+
+        // Fetch agent details
+        let agent = match repo.get_agent(&cmd.agent_id).await? {
+            Some(a) => a,
+            None => {
+                theme.print_error(&format!("Agent not found: {}", cmd.agent_id));
+                return Ok(());
+            }
+        };
+
+        println!();
+        println!("  ⚠️  Termination Request");
+        println!("  ─────────────────────────────────────");
+        println!("  Agent ID:    {}", agent.id);
+        println!("  Name:        {}", agent.name);
+        println!("  Type:        {}", agent.agent_type);
+        println!("  Server:      {}", agent.server_id);
+        println!("  Status:      {:?}", agent.status);
+        if let Some(ref reason) = cmd.reason {
+            println!("  Reason:      {}", reason);
+        }
+        println!();
+
+        // Require confirmation unless --force
+        if !cmd.force {
+            println!("  ⚠️  WARNING: This action cannot be undone!");
+            println!();
+            print!("  Type the agent name to confirm termination: ");
+            std::io::Write::flush(&mut std::io::stdout())?;
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+
+            if input.trim() != agent.name {
+                println!();
+                println!("  ❌ Termination cancelled - name mismatch");
+                return Ok(());
+            }
+        }
+
+        // Create termination service
+        let config = TerminationConfig {
+            database_url: db_url,
+            graceful_timeout: Duration::from_secs(cmd.timeout),
+            audit_enabled: true,
+        };
+
+        let service = AgentTerminationService::new(config).await?;
+
+        // Terminate agent
+        println!();
+        println!("  🔥 Initiating graceful shutdown...");
+
+        let reason = cmd
+            .reason
+            .unwrap_or_else(|| "Manual termination".to_string());
+        let result = service.terminate_agent(&cmd.agent_id, &reason).await?;
+
+        if result.success {
+            println!();
+            theme.print_success("Agent terminated successfully");
+            println!();
+            println!("  Agent ID:       {}", cmd.agent_id);
+            println!("  Shutdown Time:  {}ms", result.shutdown_duration_ms);
+            println!("  Audit ID:       {}", result.audit_id);
+            println!();
+
+            if result.tasks_migrated > 0 {
+                println!(
+                    "  📋 {} pending tasks migrated to other agents",
+                    result.tasks_migrated
+                );
+            }
+        } else {
+            theme.print_error("Termination failed");
+            if let Some(error) = result.error {
+                println!("  Error: {}", error);
+            }
+        }
+
+        Ok(())
+    })
+}

--- a/wezterm/src/cli/hire.rs
+++ b/wezterm/src/cli/hire.rs
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 CX Linux
+ * Licensed under the Business Source License 1.1
+ * You may not use this file except in compliance with the License.
+ */
+
+//! HRM AI Agent Hiring Command
+//!
+//! Deploys AI agents to managed servers with enterprise-grade compliance.
+//! This module is only available when the `hrm` feature is enabled.
+//!
+//! # Example
+//! ```bash
+//! # Deploy a DevOps agent
+//! cx hire devops --server prod-1 --name "Deploy Bot"
+//!
+//! # Deploy with custom configuration
+//! cx hire security --server sec-cluster --capabilities audit,scan,patch
+//! ```
+
+use anyhow::Result;
+use clap::Parser;
+
+#[cfg(feature = "hrm")]
+use hrm_ai::{
+    agent::AgentStatus,
+    hire::{AgentHiringService, HireConfig},
+    theme::SovereignTheme,
+};
+
+/// Agent types available for deployment
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum AgentType {
+    /// DevOps automation agent
+    Devops,
+    /// Security monitoring agent
+    Security,
+    /// Database administration agent
+    Database,
+    /// Network management agent
+    Network,
+    /// Support and helpdesk agent
+    Support,
+}
+
+impl std::fmt::Display for AgentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentType::Devops => write!(f, "devops"),
+            AgentType::Security => write!(f, "security"),
+            AgentType::Database => write!(f, "database"),
+            AgentType::Network => write!(f, "network"),
+            AgentType::Support => write!(f, "support"),
+        }
+    }
+}
+
+/// Hire (deploy) an AI agent to a server
+#[derive(Debug, Parser, Clone)]
+pub struct HireCommand {
+    /// Type of agent to deploy
+    #[arg(value_enum)]
+    pub agent_type: AgentType,
+
+    /// Target server ID for deployment
+    #[arg(long, short = 's')]
+    pub server: String,
+
+    /// Agent display name
+    #[arg(long, short = 'n')]
+    pub name: Option<String>,
+
+    /// Agent capabilities (comma-separated)
+    #[arg(long, short = 'c', value_delimiter = ',')]
+    pub capabilities: Option<Vec<String>>,
+
+    /// Skip confirmation prompt
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Output format: table, json
+    #[arg(long, default_value = "table")]
+    pub format: String,
+}
+
+impl HireCommand {
+    pub fn run(self) -> Result<()> {
+        #[cfg(feature = "hrm")]
+        {
+            run_hire_with_hrm(self)
+        }
+
+        #[cfg(not(feature = "hrm"))]
+        {
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            println!("  🔒 HRM AI Premium Feature");
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            println!();
+            println!("  The 'hire' command requires the HRM AI premium module.");
+            println!();
+            println!("  To enable HRM AI capabilities, rebuild with:");
+            println!("    cargo build --features hrm");
+            println!();
+            println!("  HRM AI Features:");
+            println!("    • cx hire <agent-type>  - Deploy AI agents");
+            println!("    • cx fire <agent-id>    - Terminate agents");
+            println!("    • PostgreSQL integration for fleet management");
+            println!("    • Enterprise compliance automation");
+            println!();
+            println!("  License: BSL 1.1 (Business Source License)");
+            println!(
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "hrm")]
+fn run_hire_with_hrm(cmd: HireCommand) -> Result<()> {
+    use tokio::runtime::Runtime;
+
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let theme = SovereignTheme::new();
+
+        // Print header
+        theme.print_header("CX Linux Agent Deployment");
+
+        println!();
+        println!("  📋 Deployment Request");
+        println!("  ─────────────────────────────────────");
+        println!("  Agent Type:  {}", cmd.agent_type);
+        println!("  Server:      {}", cmd.server);
+        if let Some(ref name) = cmd.name {
+            println!("  Name:        {}", name);
+        }
+        if let Some(ref caps) = cmd.capabilities {
+            println!("  Capabilities: {}", caps.join(", "));
+        }
+        println!();
+
+        // Confirm unless --yes
+        if !cmd.yes {
+            print!("  Deploy this agent? [y/N] ");
+            std::io::Write::flush(&mut std::io::stdout())?;
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+
+            if !input.trim().eq_ignore_ascii_case("y") {
+                println!("  ❌ Deployment cancelled");
+                return Ok(());
+            }
+        }
+
+        // Get database URL from environment
+        let db_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/cx_agents".to_string());
+
+        // Create hiring service
+        let config = HireConfig {
+            database_url: db_url,
+            default_capabilities: get_default_capabilities(&cmd.agent_type),
+        };
+
+        let service = AgentHiringService::new(config).await?;
+
+        // Generate agent name if not provided
+        let agent_name = cmd.name.unwrap_or_else(|| {
+            format!(
+                "{}-{}",
+                cmd.agent_type,
+                &uuid::Uuid::new_v4().to_string()[..8]
+            )
+        });
+
+        // Deploy agent
+        println!("  🚀 Deploying agent...");
+
+        let agent = service
+            .hire_agent(
+                &agent_name,
+                &cmd.agent_type.to_string(),
+                &cmd.server,
+                cmd.capabilities.unwrap_or_default(),
+            )
+            .await?;
+
+        println!();
+        theme.print_success(&format!("Agent deployed: {}", agent.id));
+        println!();
+        println!("  Agent ID:    {}", agent.id);
+        println!("  Name:        {}", agent.name);
+        println!("  Type:        {}", agent.agent_type);
+        println!("  Server:      {}", agent.server_id);
+        println!("  Status:      {:?}", agent.status);
+        println!();
+
+        Ok(())
+    })
+}
+
+#[cfg(feature = "hrm")]
+fn get_default_capabilities(agent_type: &AgentType) -> Vec<String> {
+    match agent_type {
+        AgentType::Devops => vec![
+            "deploy".into(),
+            "rollback".into(),
+            "scale".into(),
+            "monitor".into(),
+        ],
+        AgentType::Security => vec![
+            "audit".into(),
+            "scan".into(),
+            "patch".into(),
+            "firewall".into(),
+        ],
+        AgentType::Database => vec![
+            "backup".into(),
+            "restore".into(),
+            "optimize".into(),
+            "migrate".into(),
+        ],
+        AgentType::Network => vec![
+            "configure".into(),
+            "diagnose".into(),
+            "loadbalance".into(),
+            "dns".into(),
+        ],
+        AgentType::Support => vec![
+            "ticket".into(),
+            "escalate".into(),
+            "notify".into(),
+            "report".into(),
+        ],
+    }
+}

--- a/wezterm/src/cli/mod.rs
+++ b/wezterm/src/cli/mod.rs
@@ -36,6 +36,12 @@ pub mod snapshot;
 // CX Security: Vulnerability management
 pub mod security;
 
+// HRM AI: Premium agent management (optional feature)
+#[cfg(feature = "hrm")]
+pub mod fire;
+#[cfg(feature = "hrm")]
+pub mod hire;
+
 #[derive(Debug, Parser, Clone, Copy)]
 enum CliOutputFormatKind {
     #[command(name = "table", about = "multi line space separated table")]
@@ -226,6 +232,20 @@ Outputs the pane-id for the newly created pane on success"
     /// Security vulnerability scanning and patching
     #[command(name = "security", about = "Security vulnerability management")]
     Security(security::SecurityCommand),
+
+    // HRM AI: Premium agent management commands
+    /// Deploy an AI agent to a server (HRM AI premium feature)
+    #[cfg(feature = "hrm")]
+    #[command(name = "hire", about = "Deploy an AI agent (requires --features hrm)")]
+    Hire(hire::HireCommand),
+
+    /// Terminate an AI agent (HRM AI premium feature)
+    #[cfg(feature = "hrm")]
+    #[command(
+        name = "fire",
+        about = "Terminate an AI agent (requires --features hrm)"
+    )]
+    Fire(fire::FireCommand),
 }
 
 async fn run_cli_async(opts: &crate::Opt, cli: CliCommand) -> anyhow::Result<()> {
@@ -309,6 +329,17 @@ async fn run_cli_async(opts: &crate::Opt, cli: CliCommand) -> anyhow::Result<()>
         }
         // CX Security commands don't need the mux client
         CliSubCommand::Security(cmd) => {
+            drop(client);
+            cmd.run()
+        }
+        // HRM AI commands don't need the mux client
+        #[cfg(feature = "hrm")]
+        CliSubCommand::Hire(cmd) => {
+            drop(client);
+            cmd.run()
+        }
+        #[cfg(feature = "hrm")]
+        CliSubCommand::Fire(cmd) => {
             drop(client);
             cmd.run()
         }


### PR DESCRIPTION
Supersedes #739 (which had merge conflicts).

## Features
- Add `cx hire` command for deploying AI agents
- Add `cx fire` command for terminating AI agents
- HRM AI gated behind `--features hrm` flag (not default)
- Includes PostgreSQL integration for agent fleet management

Usage:
```bash
cargo build --features hrm  # Enable HRM AI
cx hire devops --server prod-1
cx fire <agent-id>
```