### PR TITLE
feat: add AI-powered dependency conflict predictor (issue #428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ sudo cp target/release/cx /usr/local/bin/
 | `cx ask` | Ask questions in natural language, get intelligent responses |
 | `cx status` | System health check and status overview |
 | `cx demo` | Interactive demo of CX Linux capabilities |
+| `python -m cx.dependency_conflict_predictor` | Pre-install apt/pip conflict prediction with confidence + suggestions |
 
 ### Core Capabilities
 

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -1,4 +1,8 @@
 """
+Copyright (c) 2026 AI Venture Holdings LLC
+Licensed under the Business Source License 1.1
+You may not use this file except in compliance with the License.
+
 Dependency conflict prediction for CX Linux pre-install flows.
 
 MVP scope:
@@ -18,6 +22,17 @@ import re
 import subprocess
 from dataclasses import asdict, dataclass
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+APT_MANY_MISSING_DEPS_THRESHOLD = 5
+HIGH_CONFIDENCE_THRESHOLD = 0.85
+_APT_PACKAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9+.:_-]*$")
+_PIP_SPEC_RE = re.compile(
+    r"^[A-Za-z0-9_.-]+(?:\s*(?:==|!=|>=|<=|>|<)\s*[A-Za-z0-9_.!+-]+(?:\s*,\s*(?:==|!=|>=|<=|>|<)\s*[A-Za-z0-9_.!+-]+)*)?$"
+)
 
 
 @dataclass
@@ -59,7 +74,6 @@ def _run_cmd(command: Sequence[str]) -> str:
 
 
 def _parse_name_from_alt_dep(token: str) -> str:
-    # apt-cache outputs alternatives with "pkg | other" and architecture suffixes.
     token = token.strip().split("|")[0].strip()
     token = token.split(":")[0]
     token = token.split(" ")[0]
@@ -136,13 +150,9 @@ def inspect_apt_package(
         )
         return findings
 
-    conflicts: List[str] = []
-    breaks: List[str] = []
-    depends: List[str] = []
-
-    conflicts.extend(_iter_apt_fields(show_output, "Conflicts"))
-    breaks.extend(_iter_apt_fields(show_output, "Breaks"))
-    depends.extend(_iter_apt_fields(show_output, "Depends"))
+    conflicts = _iter_apt_fields(show_output, "Conflicts")
+    breaks = _iter_apt_fields(show_output, "Breaks")
+    depends = _iter_apt_fields(show_output, "Depends")
 
     for target in conflicts:
         if target in installed:
@@ -168,9 +178,8 @@ def inspect_apt_package(
                 )
             )
 
-    # Soft risk: many unmet deps in an unstable system may indicate install friction.
     missing = [dep for dep in depends if dep and dep not in installed]
-    if len(missing) >= 5:
+    if len(missing) >= APT_MANY_MISSING_DEPS_THRESHOLD:
         findings.append(
             ConflictFinding(
                 ecosystem="apt",
@@ -185,56 +194,94 @@ def inspect_apt_package(
 
 
 def _parse_req_name_and_constraints(spec: str) -> Tuple[str, str]:
-    # MVP parser for common pip specs: name, name==x, name>=x,<y
-    match = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", spec.strip())
-    if not match:
-        return spec.strip().lower(), ""
-    return match.group(1).lower(), match.group(2).strip()
+    cleaned = spec.strip()
+    if not cleaned:
+        return "", ""
+
+    try:
+        requirement = Requirement(cleaned)
+        return requirement.name.lower(), str(requirement.specifier)
+    except InvalidRequirement:
+        match = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", cleaned)
+        if not match:
+            return cleaned.lower(), ""
+        return match.group(1).lower(), match.group(2).strip()
 
 
-def _split_version(version: str) -> Tuple[int, ...]:
-    parts = re.findall(r"\d+", version)
-    if not parts:
-        return (0,)
-    return tuple(int(part) for part in parts)
+def _parse_version(version: str) -> Version:
+    return Version(version)
 
 
 def _version_satisfies_constraint(version: str, constraint: str) -> bool:
-    # Minimal comparator support for MVP: ==,!=,>=,<=,>,< with comma-separated clauses.
     if not constraint:
         return True
 
-    parsed_version = _split_version(version)
-    comparators = {
-        "==": lambda other: parsed_version == other,
-        "!=": lambda other: parsed_version != other,
-        ">=": lambda other: parsed_version >= other,
-        "<=": lambda other: parsed_version <= other,
-        ">": lambda other: parsed_version > other,
-        "<": lambda other: parsed_version < other,
-    }
-
-    for clause in [item.strip() for item in constraint.split(",") if item.strip()]:
-        op_match = re.match(r"^(==|!=|>=|<=|>|<)\s*([A-Za-z0-9_.-]+)$", clause)
-        if not op_match:
-            continue
-        operator, rhs_raw = op_match.groups()
-        if not comparators[operator](_split_version(rhs_raw)):
-            return False
-    return True
+    try:
+        return _parse_version(version) in SpecifierSet(constraint)
+    except (InvalidSpecifier, InvalidVersion):
+        return False
 
 
 def _find_unsupported_constraint_clauses(constraint: str) -> List[str]:
     unsupported: List[str] = []
     for clause in [c.strip() for c in constraint.split(",") if c.strip()]:
-        if re.match(r"^(==|!=|>=|<=|>|<)\s*([A-Za-z0-9_.-]+)$", clause):
-            continue
-        unsupported.append(clause)
+        try:
+            SpecifierSet(clause)
+        except InvalidSpecifier:
+            unsupported.append(clause)
     return unsupported
 
 
 def _build_requested_constraint_map(requested: Sequence[Tuple[str, str]]) -> Dict[str, str]:
-    return {name: constraint for name, constraint in requested}
+    return dict(requested)
+
+
+def _extract_constraint_candidate_versions(*constraints: str) -> List[Version]:
+    candidates: Dict[str, Version] = {}
+
+    for raw in ("0", "0.1", "1", "1.0", "2", "10"):
+        candidates[raw] = Version(raw)
+
+    for constraint in constraints:
+        for raw in re.findall(r"[0-9][A-Za-z0-9_.!+-]*", constraint):
+            try:
+                version = Version(raw)
+            except InvalidVersion:
+                continue
+
+            candidates[str(version)] = version
+
+            release = list(version.release or (0,))
+            if not release:
+                continue
+
+            previous_release = release[:]
+            previous_release[-1] = max(0, previous_release[-1] - 1)
+            next_release = release[:]
+            next_release[-1] += 1
+            patch_release = release[:] + [0]
+
+            for parts in (previous_release, next_release, patch_release):
+                derived = ".".join(str(part) for part in parts)
+                candidates[derived] = Version(derived)
+
+    return list(candidates.values())
+
+
+def _constraints_overlap(left: str, right: str) -> bool:
+    if not left or not right:
+        return True
+
+    try:
+        left_spec = SpecifierSet(left)
+        right_spec = SpecifierSet(right)
+    except InvalidSpecifier:
+        return False
+
+    for candidate in _extract_constraint_candidate_versions(left, right):
+        if candidate in left_spec and candidate in right_spec:
+            return True
+    return False
 
 
 def _inspect_requested_pip_constraints(
@@ -280,11 +327,11 @@ def _inspect_reverse_dependency_risks(
         parent = (dist.metadata.get("Name") or "").lower()
         if not parent:
             continue
-        requires = dist.requires or []
-        for requirement in requires:
+
+        for requirement in dist.requires or []:
             dep_name, dep_constraint = _parse_req_name_and_constraints(requirement)
             requested_constraint = requested_constraints.get(dep_name)
-            if requested_constraint and dep_constraint and dep_constraint != requested_constraint:
+            if requested_constraint and dep_constraint and not _constraints_overlap(dep_constraint, requested_constraint):
                 findings.append(
                     ConflictFinding(
                         ecosystem="pip",
@@ -326,7 +373,7 @@ def rank_suggestions(findings: List[ConflictFinding]) -> List[ResolutionSuggesti
             )
         ]
 
-    suggestions = [
+    return [
         ResolutionSuggestion(
             action="Dry-run apt transaction (apt-get -s install ...) before applying",
             safety_score=0.96,
@@ -348,7 +395,6 @@ def rank_suggestions(findings: List[ConflictFinding]) -> List[ResolutionSuggesti
             rationale="Package removal can cascade into service disruption.",
         ),
     ]
-    return suggestions
 
 
 def predict_conflicts(
@@ -430,6 +476,16 @@ def render_cli(result: PredictionResult) -> None:
     console.print(suggestions_table)
 
 
+def _is_valid_pip_spec(spec: str) -> bool:
+    if not _PIP_SPEC_RE.fullmatch(spec):
+        return False
+    try:
+        Requirement(spec)
+    except InvalidRequirement:
+        return False
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="CX pre-install dependency conflict predictor")
     parser.add_argument("--apt", nargs="*", default=[], help="apt packages planned for install")
@@ -437,6 +493,14 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
 
     args = parser.parse_args()
+
+    invalid_apt = [package for package in args.apt if not _APT_PACKAGE_RE.fullmatch(package)]
+    if invalid_apt:
+        parser.error(f"Invalid apt package name(s): {', '.join(repr(package) for package in invalid_apt)}")
+
+    invalid_pip = [spec for spec in args.pip if not _is_valid_pip_spec(spec)]
+    if invalid_pip:
+        parser.error(f"Invalid pip requirement spec(s): {', '.join(repr(spec) for spec in invalid_pip)}")
 
     result = predict_conflicts(apt_packages=args.apt, pip_requirements=args.pip)
 
@@ -450,8 +514,7 @@ def main() -> int:
     else:
         render_cli(result)
 
-    # Non-zero code only for confidence-worthy risks.
-    if any(f.confidence >= 0.85 for f in result.findings):
+    if any(f.confidence >= HIGH_CONFIDENCE_THRESHOLD for f in result.findings):
         return 2
     return 0
 

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -294,7 +294,6 @@ def _inspect_reverse_dependency_risks(
                         evidence=f"{parent} requires '{requirement}', requested '{dep_name}{requested_constraint}'",
                     )
                 )
-                break
 
     return findings
 
@@ -349,7 +348,7 @@ def rank_suggestions(findings: List[ConflictFinding]) -> List[ResolutionSuggesti
             rationale="Package removal can cascade into service disruption.",
         ),
     ]
-    return sorted(suggestions, key=lambda x: x.safety_score, reverse=True)
+    return suggestions
 
 
 def predict_conflicts(
@@ -370,23 +369,65 @@ def predict_conflicts(
 
 
 def render_cli(result: PredictionResult) -> None:
-    print(f"Conflict prediction confidence: {result.overall_confidence:.3f}")
-    print("\nPredicted Conflicts")
-    print("-" * 80)
+    try:
+        from rich.console import Console
+        from rich.table import Table
+    except ImportError:
+        print(f"Conflict prediction confidence: {result.overall_confidence:.3f}")
+        print("\nPredicted Conflicts")
+        print("-" * 80)
 
-    if not result.findings:
-        print("none | No high-risk conflicts found")
-    else:
+        if not result.findings:
+            print("none | No high-risk conflicts found")
+        else:
+            for finding in result.findings:
+                print(
+                    f"{finding.ecosystem} | {finding.package} | {finding.issue} | "
+                    f"{finding.confidence:.3f} | {finding.evidence}"
+                )
+
+        print("\nResolution Suggestions (ranked by safety)")
+        print("-" * 80)
+        for suggestion in result.suggestions:
+            print(f"{suggestion.safety_score:.2f} | {suggestion.action} | {suggestion.rationale}")
+        return
+
+    console = Console()
+    console.print(f"Conflict prediction confidence: {result.overall_confidence:.3f}")
+
+    findings_table = Table(title="Predicted Conflicts")
+    findings_table.add_column("Ecosystem")
+    findings_table.add_column("Package")
+    findings_table.add_column("Issue")
+    findings_table.add_column("Confidence", justify="right")
+    findings_table.add_column("Evidence")
+
+    if result.findings:
         for finding in result.findings:
-            print(
-                f"{finding.ecosystem} | {finding.package} | {finding.issue} | "
-                f"{finding.confidence:.3f} | {finding.evidence}"
+            findings_table.add_row(
+                finding.ecosystem,
+                finding.package,
+                finding.issue,
+                f"{finding.confidence:.3f}",
+                finding.evidence,
             )
+    else:
+        findings_table.add_row("none", "-", "-", "0.000", "No high-risk conflicts found")
 
-    print("\nResolution Suggestions (ranked by safety)")
-    print("-" * 80)
+    suggestions_table = Table(title="Resolution Suggestions")
+    suggestions_table.add_column("Safety", justify="right")
+    suggestions_table.add_column("Action")
+    suggestions_table.add_column("Rationale")
+
     for suggestion in result.suggestions:
-        print(f"{suggestion.safety_score:.2f} | {suggestion.action} | {suggestion.rationale}")
+        suggestions_table.add_row(
+            f"{suggestion.safety_score:.2f}",
+            suggestion.action,
+            suggestion.rationale,
+        )
+
+    console.print(findings_table)
+    console.print(suggestions_table)
 
 
 def main() -> int:

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -19,6 +19,7 @@ import argparse
 import importlib.metadata
 import json
 import re
+import shutil
 import subprocess
 from dataclasses import asdict, dataclass
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
@@ -29,6 +30,8 @@ from packaging.version import InvalidVersion, Version
 
 APT_MANY_MISSING_DEPS_THRESHOLD = 5
 HIGH_CONFIDENCE_THRESHOLD = 0.85
+_SAFE_SYSTEM_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+_SAFE_COMMANDS = {"apt-cache", "dpkg-query"}
 _APT_PACKAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9+.:_-]*$")
 _PIP_SPEC_RE = re.compile(
     r"^[A-Za-z0-9_.-]+(?:\s*(?:==|!=|>=|<=|>|<)\s*[A-Za-z0-9_.!+-]+(?:\s*,\s*(?:==|!=|>=|<=|>|<)\s*[A-Za-z0-9_.!+-]+)*)?$"
@@ -64,8 +67,23 @@ class PredictionResult:
 
 
 def _run_cmd(command: Sequence[str]) -> str:
+    if not command or command[0] not in _SAFE_COMMANDS:
+        return ""
+
+    executable = shutil.which(command[0], path=_SAFE_SYSTEM_PATH)
+    if executable is None:
+        return ""
+
     try:
-        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            [executable, *command[1:]],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": _SAFE_SYSTEM_PATH},
+            cwd="/",
+            timeout=15,
+        )
     except FileNotFoundError:
         return ""
     if result.returncode != 0:

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -220,10 +220,14 @@ def _parse_req_name_and_constraints(spec: str) -> Tuple[str, str]:
         requirement = Requirement(cleaned)
         return requirement.name.lower(), str(requirement.specifier)
     except InvalidRequirement:
-        match = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", cleaned)
-        if not match:
+        name_end = 0
+        while name_end < len(cleaned) and cleaned[name_end] in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-":
+            name_end += 1
+
+        if name_end == 0:
             return cleaned.lower(), ""
-        return match.group(1).lower(), match.group(2).strip()
+
+        return cleaned[:name_end].lower(), cleaned[name_end:].strip()
 
 
 def _parse_version(version: str) -> Version:

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -1,0 +1,356 @@
+"""
+Dependency conflict prediction for CX Linux pre-install flows.
+
+MVP scope:
+- Analyze apt/dpkg metadata before install.
+- Predict conflicts with confidence scores.
+- Rank resolution suggestions by safety.
+- Include a pip conflict check path.
+- Provide CLI output for operators.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+
+
+@dataclass
+class ConflictFinding:
+    ecosystem: str  # apt | pip
+    package: str
+    issue: str
+    confidence: float
+    evidence: str
+
+
+@dataclass
+class ResolutionSuggestion:
+    action: str
+    safety_score: float
+    rationale: str
+
+
+@dataclass
+class PredictionResult:
+    findings: List[ConflictFinding]
+    suggestions: List[ResolutionSuggestion]
+
+    @property
+    def overall_confidence(self) -> float:
+        if not self.findings:
+            return 0.0
+        return round(sum(item.confidence for item in self.findings) / len(self.findings), 3)
+
+
+def _run_cmd(command: Sequence[str]) -> str:
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _parse_name_from_alt_dep(token: str) -> str:
+    # apt-cache outputs alternatives with "pkg | other" and architecture suffixes.
+    token = token.strip().split("|")[0].strip()
+    token = token.split(":")[0]
+    token = token.split(" ")[0]
+    return token
+
+
+def _parse_apt_field(line: str, field: str) -> List[str]:
+    if not line.startswith(field + ":"):
+        return []
+    value = line.split(":", 1)[1].strip()
+    if not value:
+        return []
+    items: List[str] = []
+    for part in value.split(","):
+        part = part.strip()
+        name = _parse_name_from_alt_dep(part)
+        if name:
+            items.append(name)
+    return items
+
+
+def get_installed_dpkg_packages(run_cmd: Callable[[Sequence[str]], str] = _run_cmd) -> Dict[str, str]:
+    output = run_cmd(["dpkg-query", "-W", "-f=${Package}\t${Version}\n"])
+    installed: Dict[str, str] = {}
+    for row in output.splitlines():
+        cols = row.strip().split("\t")
+        if len(cols) == 2:
+            installed[cols[0]] = cols[1]
+    return installed
+
+
+def inspect_apt_package(
+    package: str,
+    installed: Dict[str, str],
+    run_cmd: Callable[[Sequence[str]], str] = _run_cmd,
+) -> List[ConflictFinding]:
+    findings: List[ConflictFinding] = []
+
+    show_output = run_cmd(["apt-cache", "show", package])
+    if not show_output:
+        findings.append(
+            ConflictFinding(
+                ecosystem="apt",
+                package=package,
+                issue="package-not-found",
+                confidence=0.8,
+                evidence=f"apt-cache show {package} returned no metadata",
+            )
+        )
+        return findings
+
+    conflicts: List[str] = []
+    breaks: List[str] = []
+    depends: List[str] = []
+
+    for line in show_output.splitlines():
+        conflicts.extend(_parse_apt_field(line, "Conflicts"))
+        breaks.extend(_parse_apt_field(line, "Breaks"))
+        depends.extend(_parse_apt_field(line, "Depends"))
+
+    for target in conflicts:
+        if target in installed:
+            findings.append(
+                ConflictFinding(
+                    ecosystem="apt",
+                    package=package,
+                    issue="conflicts-installed-package",
+                    confidence=0.95,
+                    evidence=f"{package} Conflicts with installed package {target}",
+                )
+            )
+
+    for target in breaks:
+        if target in installed:
+            findings.append(
+                ConflictFinding(
+                    ecosystem="apt",
+                    package=package,
+                    issue="breaks-installed-package",
+                    confidence=0.9,
+                    evidence=f"{package} Breaks installed package {target}",
+                )
+            )
+
+    # Soft risk: many unmet deps in an unstable system may indicate install friction.
+    missing = [dep for dep in depends if dep and dep not in installed]
+    if len(missing) >= 5:
+        findings.append(
+            ConflictFinding(
+                ecosystem="apt",
+                package=package,
+                issue="many-missing-dependencies",
+                confidence=0.55,
+                evidence=f"{package} has {len(missing)} dependencies not currently installed",
+            )
+        )
+
+    return findings
+
+
+def _parse_req_name_and_constraints(spec: str) -> Tuple[str, str]:
+    # MVP parser for common pip specs: name, name==x, name>=x,<y
+    m = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", spec.strip())
+    if not m:
+        return spec.strip().lower(), ""
+    return m.group(1).lower(), m.group(2).strip()
+
+
+def _version_satisfies_constraint(version: str, constraint: str) -> bool:
+    # Minimal comparator support for MVP: ==,!=,>=,<=,>,< with comma-separated clauses.
+    if not constraint:
+        return True
+
+    def split_version(v: str) -> Tuple[int, ...]:
+        nums = re.findall(r"\d+", v)
+        if not nums:
+            return (0,)
+        return tuple(int(x) for x in nums)
+
+    v = split_version(version)
+    for clause in [c.strip() for c in constraint.split(",") if c.strip()]:
+        op_match = re.match(r"^(==|!=|>=|<=|>|<)\s*([A-Za-z0-9_.-]+)$", clause)
+        if not op_match:
+            continue
+        op, rhs_raw = op_match.groups()
+        rhs = split_version(rhs_raw)
+        if op == "==" and not (v == rhs):
+            return False
+        if op == "!=" and not (v != rhs):
+            return False
+        if op == ">=" and not (v >= rhs):
+            return False
+        if op == "<=" and not (v <= rhs):
+            return False
+        if op == ">" and not (v > rhs):
+            return False
+        if op == "<" and not (v < rhs):
+            return False
+    return True
+
+
+def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding]:
+    findings: List[ConflictFinding] = []
+    if not requested_specs:
+        return findings
+
+    installed: Dict[str, str] = {}
+    for dist in importlib.metadata.distributions():
+        name = (dist.metadata.get("Name") or "").lower()
+        if name:
+            installed[name] = dist.version
+
+    requested = [_parse_req_name_and_constraints(spec) for spec in requested_specs]
+
+    # 1) Direct constraint mismatch with already-installed package.
+    for name, constraint in requested:
+        if name in installed and constraint and not _version_satisfies_constraint(installed[name], constraint):
+            findings.append(
+                ConflictFinding(
+                    ecosystem="pip",
+                    package=name,
+                    issue="installed-version-violates-requested-constraint",
+                    confidence=0.85,
+                    evidence=f"Installed {name}=={installed[name]} does not satisfy {constraint}",
+                )
+            )
+
+    # 2) Reverse dependency check: existing packages requiring a conflicting range.
+    req_map = {name: constraint for name, constraint in requested}
+    for dist in importlib.metadata.distributions():
+        parent = (dist.metadata.get("Name") or "").lower()
+        if not parent:
+            continue
+        requires = dist.requires or []
+        for req in requires:
+            dep_name, dep_constraint = _parse_req_name_and_constraints(req)
+            if dep_name in req_map and req_map[dep_name]:
+                # Requested constraint likely conflicts with current parent expectation.
+                if dep_constraint and dep_constraint != req_map[dep_name]:
+                    findings.append(
+                        ConflictFinding(
+                            ecosystem="pip",
+                            package=dep_name,
+                            issue="reverse-dependency-constraint-risk",
+                            confidence=0.65,
+                            evidence=f"{parent} requires '{req}', requested '{dep_name}{req_map[dep_name]}'",
+                        )
+                    )
+                    break
+
+    return findings
+
+
+def rank_suggestions(findings: List[ConflictFinding]) -> List[ResolutionSuggestion]:
+    if not findings:
+        return [
+            ResolutionSuggestion(
+                action="Proceed with install",
+                safety_score=0.97,
+                rationale="No obvious package conflicts detected in current metadata scan.",
+            )
+        ]
+
+    suggestions = [
+        ResolutionSuggestion(
+            action="Dry-run apt transaction (apt-get -s install ...) before applying",
+            safety_score=0.96,
+            rationale="Simulation validates solver decisions without changing system state.",
+        ),
+        ResolutionSuggestion(
+            action="Prefer non-destructive version pinning over package removal",
+            safety_score=0.9,
+            rationale="Pinning lowers breakage risk while preserving currently working packages.",
+        ),
+        ResolutionSuggestion(
+            action="Isolate risky pip installs in virtualenv",
+            safety_score=0.88,
+            rationale="Environment isolation prevents global dependency contamination.",
+        ),
+        ResolutionSuggestion(
+            action="Remove conflicting packages only after explicit review",
+            safety_score=0.52,
+            rationale="Package removal can cascade into service disruption.",
+        ),
+    ]
+    return sorted(suggestions, key=lambda x: x.safety_score, reverse=True)
+
+
+def predict_conflicts(
+    apt_packages: List[str],
+    pip_requirements: Optional[List[str]] = None,
+    run_cmd: Callable[[Sequence[str]], str] = _run_cmd,
+) -> PredictionResult:
+    installed = get_installed_dpkg_packages(run_cmd=run_cmd)
+    findings: List[ConflictFinding] = []
+
+    for package in apt_packages:
+        findings.extend(inspect_apt_package(package, installed=installed, run_cmd=run_cmd))
+
+    findings.extend(inspect_pip_requirements(pip_requirements or []))
+
+    suggestions = rank_suggestions(findings)
+    return PredictionResult(findings=findings, suggestions=suggestions)
+
+
+def render_cli(result: PredictionResult) -> None:
+    print(f"Conflict prediction confidence: {result.overall_confidence:.3f}")
+    print("\nPredicted Conflicts")
+    print("-" * 80)
+
+    if not result.findings:
+        print("none | No high-risk conflicts found")
+    else:
+        for finding in result.findings:
+            print(
+                f"{finding.ecosystem} | {finding.package} | {finding.issue} | "
+                f"{finding.confidence:.3f} | {finding.evidence}"
+            )
+
+    print("\nResolution Suggestions (ranked by safety)")
+    print("-" * 80)
+    for suggestion in result.suggestions:
+        print(f"{suggestion.safety_score:.2f} | {suggestion.action} | {suggestion.rationale}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CX pre-install dependency conflict predictor")
+    parser.add_argument("--apt", nargs="*", default=[], help="apt packages planned for install")
+    parser.add_argument("--pip", nargs="*", default=[], help="pip requirement specs planned for install")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    args = parser.parse_args()
+
+    result = predict_conflicts(apt_packages=args.apt, pip_requirements=args.pip)
+
+    if args.json:
+        payload = {
+            "overall_confidence": result.overall_confidence,
+            "findings": [asdict(f) for f in result.findings],
+            "suggestions": [asdict(s) for s in result.suggestions],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        render_cli(result)
+
+    # Non-zero code only for confidence-worthy risks.
+    if any(f.confidence >= 0.85 for f in result.findings):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -259,7 +259,7 @@ def _extract_constraint_candidate_versions(*constraints: str) -> List[Version]:
             previous_release[-1] = max(0, previous_release[-1] - 1)
             next_release = release[:]
             next_release[-1] += 1
-            patch_release = release[:] + [0]
+            patch_release = [*release, 0]
 
             for parts in (previous_release, next_release, patch_release):
                 derived = ".".join(str(part) for part in parts)

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -186,10 +186,17 @@ def inspect_apt_package(
 
 def _parse_req_name_and_constraints(spec: str) -> Tuple[str, str]:
     # MVP parser for common pip specs: name, name==x, name>=x,<y
-    m = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", spec.strip())
-    if not m:
+    match = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*)$", spec.strip())
+    if not match:
         return spec.strip().lower(), ""
-    return m.group(1).lower(), m.group(2).strip()
+    return match.group(1).lower(), match.group(2).strip()
+
+
+def _split_version(version: str) -> Tuple[int, ...]:
+    parts = re.findall(r"\d+", version)
+    if not parts:
+        return (0,)
+    return tuple(int(part) for part in parts)
 
 
 def _version_satisfies_constraint(version: str, constraint: str) -> bool:
@@ -197,30 +204,22 @@ def _version_satisfies_constraint(version: str, constraint: str) -> bool:
     if not constraint:
         return True
 
-    def split_version(v: str) -> Tuple[int, ...]:
-        nums = re.findall(r"\d+", v)
-        if not nums:
-            return (0,)
-        return tuple(int(x) for x in nums)
+    parsed_version = _split_version(version)
+    comparators = {
+        "==": lambda other: parsed_version == other,
+        "!=": lambda other: parsed_version != other,
+        ">=": lambda other: parsed_version >= other,
+        "<=": lambda other: parsed_version <= other,
+        ">": lambda other: parsed_version > other,
+        "<": lambda other: parsed_version < other,
+    }
 
-    v = split_version(version)
-    for clause in [c.strip() for c in constraint.split(",") if c.strip()]:
+    for clause in [item.strip() for item in constraint.split(",") if item.strip()]:
         op_match = re.match(r"^(==|!=|>=|<=|>|<)\s*([A-Za-z0-9_.-]+)$", clause)
         if not op_match:
             continue
-        op, rhs_raw = op_match.groups()
-        rhs = split_version(rhs_raw)
-        if op == "==" and not (v == rhs):
-            return False
-        if op == "!=" and not (v != rhs):
-            return False
-        if op == ">=" and not (v >= rhs):
-            return False
-        if op == "<=" and not (v <= rhs):
-            return False
-        if op == ">" and not (v > rhs):
-            return False
-        if op == "<" and not (v < rhs):
+        operator, rhs_raw = op_match.groups()
+        if not comparators[operator](_split_version(rhs_raw)):
             return False
     return True
 
@@ -234,23 +233,18 @@ def _find_unsupported_constraint_clauses(constraint: str) -> List[str]:
     return unsupported
 
 
-def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding]:
+def _build_requested_constraint_map(requested: Sequence[Tuple[str, str]]) -> Dict[str, str]:
+    return {name: constraint for name, constraint in requested}
+
+
+def _inspect_requested_pip_constraints(
+    requested: Sequence[Tuple[str, str]],
+    installed: Dict[str, str],
+) -> List[ConflictFinding]:
     findings: List[ConflictFinding] = []
-    if not requested_specs:
-        return findings
 
-    installed: Dict[str, str] = {}
-    for dist in importlib.metadata.distributions():
-        name = (dist.metadata.get("Name") or "").lower()
-        if name:
-            installed[name] = dist.version
-
-    requested = [_parse_req_name_and_constraints(spec) for spec in requested_specs]
-
-    # 1) Direct constraint mismatch with already-installed package.
     for name, constraint in requested:
-        unsupported = _find_unsupported_constraint_clauses(constraint)
-        for clause in unsupported:
+        for clause in _find_unsupported_constraint_clauses(constraint):
             findings.append(
                 ConflictFinding(
                     ecosystem="pip",
@@ -260,40 +254,66 @@ def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding
                     evidence=f"Unsupported version clause '{clause}' in requested constraint '{constraint}'",
                 )
             )
-        if name in installed and constraint and not _version_satisfies_constraint(installed[name], constraint):
+
+        installed_version = installed.get(name)
+        if installed_version and constraint and not _version_satisfies_constraint(installed_version, constraint):
             findings.append(
                 ConflictFinding(
                     ecosystem="pip",
                     package=name,
                     issue="installed-version-violates-requested-constraint",
                     confidence=0.85,
-                    evidence=f"Installed {name}=={installed[name]} does not satisfy {constraint}",
+                    evidence=f"Installed {name}=={installed_version} does not satisfy {constraint}",
                 )
             )
 
-    # 2) Reverse dependency check: existing packages requiring a conflicting range.
-    req_map = {name: constraint for name, constraint in requested}
-    for dist in importlib.metadata.distributions():
+    return findings
+
+
+def _inspect_reverse_dependency_risks(
+    distributions: Sequence[importlib.metadata.Distribution],
+    requested_constraints: Dict[str, str],
+) -> List[ConflictFinding]:
+    findings: List[ConflictFinding] = []
+
+    for dist in distributions:
         parent = (dist.metadata.get("Name") or "").lower()
         if not parent:
             continue
         requires = dist.requires or []
-        for req in requires:
-            dep_name, dep_constraint = _parse_req_name_and_constraints(req)
-            if dep_name in req_map and req_map[dep_name]:
-                # Requested constraint likely conflicts with current parent expectation.
-                if dep_constraint and dep_constraint != req_map[dep_name]:
-                    findings.append(
-                        ConflictFinding(
-                            ecosystem="pip",
-                            package=dep_name,
-                            issue="reverse-dependency-constraint-risk",
-                            confidence=0.65,
-                            evidence=f"{parent} requires '{req}', requested '{dep_name}{req_map[dep_name]}'",
-                        )
+        for requirement in requires:
+            dep_name, dep_constraint = _parse_req_name_and_constraints(requirement)
+            requested_constraint = requested_constraints.get(dep_name)
+            if requested_constraint and dep_constraint and dep_constraint != requested_constraint:
+                findings.append(
+                    ConflictFinding(
+                        ecosystem="pip",
+                        package=dep_name,
+                        issue="reverse-dependency-constraint-risk",
+                        confidence=0.65,
+                        evidence=f"{parent} requires '{requirement}', requested '{dep_name}{requested_constraint}'",
                     )
-                    break
+                )
+                break
 
+    return findings
+
+
+def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding]:
+    findings: List[ConflictFinding] = []
+    if not requested_specs:
+        return findings
+
+    distributions = list(importlib.metadata.distributions())
+    installed: Dict[str, str] = {}
+    for dist in distributions:
+        name = (dist.metadata.get("Name") or "").lower()
+        if name:
+            installed[name] = dist.version
+
+    requested = [_parse_req_name_and_constraints(spec) for spec in requested_specs]
+    findings.extend(_inspect_requested_pip_constraints(requested, installed))
+    findings.extend(_inspect_reverse_dependency_risks(distributions, _build_requested_constraint_map(requested)))
     return findings
 
 

--- a/cx/dependency_conflict_predictor.py
+++ b/cx/dependency_conflict_predictor.py
@@ -20,7 +20,6 @@ from dataclasses import asdict, dataclass
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 
-
 @dataclass
 class ConflictFinding:
     ecosystem: str  # apt | pip
@@ -82,6 +81,31 @@ def _parse_apt_field(line: str, field: str) -> List[str]:
     return items
 
 
+def _iter_apt_fields(show_output: str, field: str) -> List[str]:
+    items: List[str] = []
+    current_value = ""
+
+    for raw_line in show_output.splitlines():
+        if raw_line.startswith(field + ":"):
+            if current_value:
+                items.extend(_parse_apt_field(f"{field}: {current_value}", field))
+            current_value = raw_line.split(":", 1)[1].strip()
+            continue
+
+        if current_value and raw_line.startswith(" "):
+            current_value = f"{current_value} {raw_line.strip()}".strip()
+            continue
+
+        if current_value:
+            items.extend(_parse_apt_field(f"{field}: {current_value}", field))
+            current_value = ""
+
+    if current_value:
+        items.extend(_parse_apt_field(f"{field}: {current_value}", field))
+
+    return items
+
+
 def get_installed_dpkg_packages(run_cmd: Callable[[Sequence[str]], str] = _run_cmd) -> Dict[str, str]:
     output = run_cmd(["dpkg-query", "-W", "-f=${Package}\t${Version}\n"])
     installed: Dict[str, str] = {}
@@ -116,10 +140,9 @@ def inspect_apt_package(
     breaks: List[str] = []
     depends: List[str] = []
 
-    for line in show_output.splitlines():
-        conflicts.extend(_parse_apt_field(line, "Conflicts"))
-        breaks.extend(_parse_apt_field(line, "Breaks"))
-        depends.extend(_parse_apt_field(line, "Depends"))
+    conflicts.extend(_iter_apt_fields(show_output, "Conflicts"))
+    breaks.extend(_iter_apt_fields(show_output, "Breaks"))
+    depends.extend(_iter_apt_fields(show_output, "Depends"))
 
     for target in conflicts:
         if target in installed:
@@ -202,6 +225,15 @@ def _version_satisfies_constraint(version: str, constraint: str) -> bool:
     return True
 
 
+def _find_unsupported_constraint_clauses(constraint: str) -> List[str]:
+    unsupported: List[str] = []
+    for clause in [c.strip() for c in constraint.split(",") if c.strip()]:
+        if re.match(r"^(==|!=|>=|<=|>|<)\s*([A-Za-z0-9_.-]+)$", clause):
+            continue
+        unsupported.append(clause)
+    return unsupported
+
+
 def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding]:
     findings: List[ConflictFinding] = []
     if not requested_specs:
@@ -217,6 +249,17 @@ def inspect_pip_requirements(requested_specs: List[str]) -> List[ConflictFinding
 
     # 1) Direct constraint mismatch with already-installed package.
     for name, constraint in requested:
+        unsupported = _find_unsupported_constraint_clauses(constraint)
+        for clause in unsupported:
+            findings.append(
+                ConflictFinding(
+                    ecosystem="pip",
+                    package=name,
+                    issue="unsupported-constraint",
+                    confidence=0.7,
+                    evidence=f"Unsupported version clause '{clause}' in requested constraint '{constraint}'",
+                )
+            )
         if name in installed and constraint and not _version_satisfies_constraint(installed[name], constraint):
             findings.append(
                 ConflictFinding(

--- a/cx/requirements.txt
+++ b/cx/requirements.txt
@@ -4,6 +4,7 @@
 # Core dependencies
 rich>=13.0.0                    # Terminal UI and console formatting
 psutil>=5.8.0                   # System and process monitoring
+packaging>=24.0                 # PEP 440 version and specifier parsing
 
 # Enterprise security dependencies
 cryptography>=41.0.0            # Data encryption for sensitive fields (email addresses)

--- a/docs/dependency-conflict-predictor.md
+++ b/docs/dependency-conflict-predictor.md
@@ -1,0 +1,37 @@
+# Dependency Conflict Predictor (MVP)
+
+CX Linux includes an MVP pre-install dependency conflict predictor for package operations.
+
+## What it checks
+
+- **apt/dpkg path**
+  - Reads installed package set from `dpkg-query`
+  - Reads package metadata from `apt-cache show`
+  - Flags likely `Conflicts`/`Breaks` against currently installed packages
+  - Emits a confidence score per finding
+
+- **pip path**
+  - Parses requested pip constraints (e.g. `urllib3==2.0.0`)
+  - Compares against current Python environment metadata
+  - Flags direct constraint mismatches and reverse dependency risks
+
+- **Resolution suggestions**
+  - Ranked by safety (higher first)
+  - Includes dry-run and isolation-first guidance
+
+## CLI usage
+
+```bash
+python -m cx.dependency_conflict_predictor --apt nginx postgresql --pip "urllib3==2.1.0"
+```
+
+JSON output:
+
+```bash
+python -m cx.dependency_conflict_predictor --apt nginx --json
+```
+
+Exit code behavior:
+
+- `0`: no high-confidence conflict detected
+- `2`: at least one high-confidence conflict found (`confidence >= 0.85`)

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -14,6 +14,7 @@ from cx.dependency_conflict_predictor import (
     inspect_apt_package,
     inspect_pip_requirements,
     predict_conflicts,
+    rank_suggestions,
 )
 
 
@@ -132,6 +133,39 @@ Breaks: unused-lib,
         self.assertGreaterEqual(len(result.suggestions), 1)
         self.assertGreaterEqual(result.overall_confidence, 0.5)
         self.assertTrue(all(f.issue != "unsupported-constraint" for f in result.findings))
+
+    @patch("importlib.metadata.distributions")
+    def test_pip_reports_multiple_reverse_dependency_risks_per_distribution(self, mock_distributions):
+        class FakeDist:
+            def __init__(self, name, version, requires=None):
+                self.metadata = {"Name": name}
+                self.version = version
+                self.requires = requires or []
+
+        mock_distributions.return_value = [
+            FakeDist(
+                "service-a",
+                "1.0.0",
+                ["urllib3<2.0", "requests<2.30"],
+            ),
+            FakeDist("urllib3", "1.26.6", []),
+            FakeDist("requests", "2.28.0", []),
+        ]
+
+        findings = inspect_pip_requirements(["urllib3==2.1.0", "requests==2.31.0"])
+        reverse_dependency_findings = [
+            finding for finding in findings if finding.issue == "reverse-dependency-constraint-risk"
+        ]
+
+        self.assertEqual(len(reverse_dependency_findings), 2)
+        self.assertEqual({finding.package for finding in reverse_dependency_findings}, {"urllib3", "requests"})
+
+    def test_rank_suggestions_preserves_descending_safety_order(self):
+        suggestions = rank_suggestions([])
+        self.assertEqual(
+            [suggestion.safety_score for suggestion in suggestions],
+            sorted((suggestion.safety_score for suggestion in suggestions), reverse=True),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from cx.dependency_conflict_predictor import (
     ConflictFinding,
+    _run_cmd,
     _version_satisfies_constraint,
     inspect_apt_package,
     inspect_pip_requirements,
@@ -164,6 +165,31 @@ Breaks: unused-lib,
             [suggestion.safety_score for suggestion in suggestions],
             sorted((suggestion.safety_score for suggestion in suggestions), reverse=True),
         )
+
+    @patch("cx.dependency_conflict_predictor.subprocess.run")
+    @patch("cx.dependency_conflict_predictor.shutil.which", return_value="/usr/bin/apt-cache")
+    def test_run_cmd_uses_resolved_safe_binary(self, mock_which, mock_run):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "Package: demo\n"
+
+        output = _run_cmd(["apt-cache", "show", "demo-app"])
+
+        self.assertEqual(output, "Package: demo\n")
+        mock_which.assert_called_once_with("apt-cache", path="/usr/bin:/bin:/usr/sbin:/sbin")
+        mock_run.assert_called_once_with(
+            ["/usr/bin/apt-cache", "show", "demo-app"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"},
+            cwd="/",
+            timeout=15,
+        )
+
+    @patch("cx.dependency_conflict_predictor.subprocess.run")
+    def test_run_cmd_rejects_non_allowlisted_binary(self, mock_run):
+        self.assertEqual(_run_cmd(["python3", "-c", "print(1)"]), "")
+        mock_run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -1,3 +1,11 @@
+"""
+Copyright (c) 2026 AI Venture Holdings LLC
+Licensed under the Business Source License 1.1
+You may not use this file except in compliance with the License.
+
+Regression tests for the dependency conflict predictor.
+"""
+
 import unittest
 from unittest.mock import patch
 
@@ -31,6 +39,31 @@ Breaks: old-demo
         issues = {f.issue for f in findings}
         self.assertIn("conflicts-installed-package", issues)
 
+    def test_apt_conflict_detection_with_continuation_lines(self):
+        installed = {"libssl1.1": "1.1.1", "legacy-lib": "2.0", "bash": "5.2"}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["apt-cache", "show"]:
+                return """Package: demo-app
+Depends: libc6,
+ python3,
+ bash
+Conflicts: old-lib,
+ libssl1.1
+Breaks: unused-lib,
+ legacy-lib
+"""
+            return ""
+
+        findings = inspect_apt_package("demo-app", installed=installed, run_cmd=fake_run)
+        issues = {f.issue for f in findings}
+        evidence = "\n".join(f.evidence for f in findings)
+
+        self.assertIn("conflicts-installed-package", issues)
+        self.assertIn("breaks-installed-package", issues)
+        self.assertIn("libssl1.1", evidence)
+        self.assertIn("legacy-lib", evidence)
+
     def test_apt_package_not_found(self):
         findings = inspect_apt_package(
             "missing-app",
@@ -58,6 +91,23 @@ Breaks: old-demo
         self.assertIn("installed-version-violates-requested-constraint", issues)
 
     @patch("importlib.metadata.distributions")
+    def test_pip_reports_unsupported_constraints(self, mock_distributions):
+        class FakeDist:
+            def __init__(self, name, version, requires=None):
+                self.metadata = {"Name": name}
+                self.version = version
+                self.requires = requires or []
+
+        mock_distributions.return_value = [FakeDist("urllib3", "1.26.6", [])]
+
+        findings = inspect_pip_requirements(["urllib3~=1.26"])
+        issues = {f.issue for f in findings}
+        evidence = "\n".join(f.evidence for f in findings)
+
+        self.assertIn("unsupported-constraint", issues)
+        self.assertIn("~=1.26", evidence)
+
+    @patch("importlib.metadata.distributions")
     def test_predict_conflicts_includes_suggestions(self, mock_distributions):
         class FakeDist:
             def __init__(self, name, version, requires=None):
@@ -81,6 +131,7 @@ Breaks: old-demo
         )
         self.assertGreaterEqual(len(result.suggestions), 1)
         self.assertGreaterEqual(result.overall_confidence, 0.5)
+        self.assertTrue(all(f.issue != "unsupported-constraint" for f in result.findings))
 
 
 if __name__ == "__main__":

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from cx.dependency_conflict_predictor import (
     ConflictFinding,
+    _parse_req_name_and_constraints,
     _run_cmd,
     _version_satisfies_constraint,
     inspect_apt_package,
@@ -36,6 +37,11 @@ class TestDependencyConflictPredictor(unittest.TestCase):
         self.assertTrue(_version_satisfies_constraint("1.2.3", ""))
         self.assertTrue(_version_satisfies_constraint("1.2.3", "!=2.0.0"))
         self.assertFalse(_version_satisfies_constraint("1.2.3", ">>2.0.0"))
+
+    def test_parse_req_name_and_constraints_avoids_regex_fallback(self):
+        self.assertEqual(_parse_req_name_and_constraints("urllib3=>1.26"), ("urllib3", "=>1.26"))
+        self.assertEqual(_parse_req_name_and_constraints("  requests ~=2.31"), ("requests", "~=2.31"))
+        self.assertEqual(_parse_req_name_and_constraints(">=1.0"), (">=1.0", ""))
 
     def test_apt_conflict_detection(self):
         installed = {"libssl1.1": "1.1.1", "bash": "5.2"}

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch
+
+from cx.dependency_conflict_predictor import (
+    _version_satisfies_constraint,
+    inspect_apt_package,
+    inspect_pip_requirements,
+    predict_conflicts,
+)
+
+
+class TestDependencyConflictPredictor(unittest.TestCase):
+    def test_version_constraint_helper(self):
+        self.assertTrue(_version_satisfies_constraint("1.2.3", ">=1.0,<2.0"))
+        self.assertFalse(_version_satisfies_constraint("2.1.0", ">=1.0,<2.0"))
+        self.assertTrue(_version_satisfies_constraint("1.2.3", "==1.2.3"))
+
+    def test_apt_conflict_detection(self):
+        installed = {"libssl1.1": "1.1.1", "bash": "5.2"}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["apt-cache", "show"]:
+                return """Package: demo-app
+Depends: libc6, python3
+Conflicts: libssl1.1
+Breaks: old-demo
+"""
+            return ""
+
+        findings = inspect_apt_package("demo-app", installed=installed, run_cmd=fake_run)
+        issues = {f.issue for f in findings}
+        self.assertIn("conflicts-installed-package", issues)
+
+    def test_apt_package_not_found(self):
+        findings = inspect_apt_package(
+            "missing-app",
+            installed={},
+            run_cmd=lambda _cmd: "",
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].issue, "package-not-found")
+
+    @patch("importlib.metadata.distributions")
+    def test_pip_conflict_detection(self, mock_distributions):
+        class FakeDist:
+            def __init__(self, name, version, requires=None):
+                self.metadata = {"Name": name}
+                self.version = version
+                self.requires = requires or []
+
+        mock_distributions.return_value = [
+            FakeDist("requests", "2.28.0", ["urllib3>=1.25,<1.27"]),
+            FakeDist("urllib3", "1.26.6", []),
+        ]
+
+        findings = inspect_pip_requirements(["urllib3==2.1.0"])
+        issues = {f.issue for f in findings}
+        self.assertIn("installed-version-violates-requested-constraint", issues)
+
+    @patch("importlib.metadata.distributions")
+    def test_predict_conflicts_includes_suggestions(self, mock_distributions):
+        class FakeDist:
+            def __init__(self, name, version, requires=None):
+                self.metadata = {"Name": name}
+                self.version = version
+                self.requires = requires or []
+
+        mock_distributions.return_value = [FakeDist("urllib3", "1.26.6", [])]
+
+        def fake_run(cmd):
+            if cmd[0] == "dpkg-query":
+                return "bash\t5.2\n"
+            if cmd[:2] == ["apt-cache", "show"]:
+                return "Package: demo\nDepends: bash\n"
+            return ""
+
+        result = predict_conflicts(
+            apt_packages=["demo"],
+            pip_requirements=["urllib3==2.0.0"],
+            run_cmd=fake_run,
+        )
+        self.assertGreaterEqual(len(result.suggestions), 1)
+        self.assertGreaterEqual(result.overall_confidence, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dependency_conflict_predictor.py
+++ b/tests/test_dependency_conflict_predictor.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import patch
 
 from cx.dependency_conflict_predictor import (
+    ConflictFinding,
     _version_satisfies_constraint,
     inspect_apt_package,
     inspect_pip_requirements,
@@ -18,11 +19,22 @@ from cx.dependency_conflict_predictor import (
 )
 
 
+class FakeDist:
+    def __init__(self, name, version, requires=None):
+        self.metadata = {"Name": name}
+        self.version = version
+        self.requires = requires or []
+
+
 class TestDependencyConflictPredictor(unittest.TestCase):
     def test_version_constraint_helper(self):
         self.assertTrue(_version_satisfies_constraint("1.2.3", ">=1.0,<2.0"))
         self.assertFalse(_version_satisfies_constraint("2.1.0", ">=1.0,<2.0"))
         self.assertTrue(_version_satisfies_constraint("1.2.3", "==1.2.3"))
+        self.assertTrue(_version_satisfies_constraint("1.0a1", "==1.0a1"))
+        self.assertTrue(_version_satisfies_constraint("1.2.3", ""))
+        self.assertTrue(_version_satisfies_constraint("1.2.3", "!=2.0.0"))
+        self.assertFalse(_version_satisfies_constraint("1.2.3", ">>2.0.0"))
 
     def test_apt_conflict_detection(self):
         installed = {"libssl1.1": "1.1.1", "bash": "5.2"}
@@ -76,12 +88,6 @@ Breaks: unused-lib,
 
     @patch("importlib.metadata.distributions")
     def test_pip_conflict_detection(self, mock_distributions):
-        class FakeDist:
-            def __init__(self, name, version, requires=None):
-                self.metadata = {"Name": name}
-                self.version = version
-                self.requires = requires or []
-
         mock_distributions.return_value = [
             FakeDist("requests", "2.28.0", ["urllib3>=1.25,<1.27"]),
             FakeDist("urllib3", "1.26.6", []),
@@ -93,29 +99,17 @@ Breaks: unused-lib,
 
     @patch("importlib.metadata.distributions")
     def test_pip_reports_unsupported_constraints(self, mock_distributions):
-        class FakeDist:
-            def __init__(self, name, version, requires=None):
-                self.metadata = {"Name": name}
-                self.version = version
-                self.requires = requires or []
-
         mock_distributions.return_value = [FakeDist("urllib3", "1.26.6", [])]
 
-        findings = inspect_pip_requirements(["urllib3~=1.26"])
+        findings = inspect_pip_requirements(["urllib3=>1.26"])
         issues = {f.issue for f in findings}
         evidence = "\n".join(f.evidence for f in findings)
 
         self.assertIn("unsupported-constraint", issues)
-        self.assertIn("~=1.26", evidence)
+        self.assertIn("=>1.26", evidence)
 
     @patch("importlib.metadata.distributions")
     def test_predict_conflicts_includes_suggestions(self, mock_distributions):
-        class FakeDist:
-            def __init__(self, name, version, requires=None):
-                self.metadata = {"Name": name}
-                self.version = version
-                self.requires = requires or []
-
         mock_distributions.return_value = [FakeDist("urllib3", "1.26.6", [])]
 
         def fake_run(cmd):
@@ -136,12 +130,6 @@ Breaks: unused-lib,
 
     @patch("importlib.metadata.distributions")
     def test_pip_reports_multiple_reverse_dependency_risks_per_distribution(self, mock_distributions):
-        class FakeDist:
-            def __init__(self, name, version, requires=None):
-                self.metadata = {"Name": name}
-                self.version = version
-                self.requires = requires or []
-
         mock_distributions.return_value = [
             FakeDist(
                 "service-a",
@@ -161,7 +149,17 @@ Breaks: unused-lib,
         self.assertEqual({finding.package for finding in reverse_dependency_findings}, {"urllib3", "requests"})
 
     def test_rank_suggestions_preserves_descending_safety_order(self):
-        suggestions = rank_suggestions([])
+        findings = [
+            ConflictFinding(
+                ecosystem="apt",
+                package="demo-app",
+                issue="conflicts-installed-package",
+                confidence=0.95,
+                evidence="demo-app conflicts with installed package libssl1.1",
+            )
+        ]
+        suggestions = rank_suggestions(findings)
+        self.assertGreater(len(suggestions), 1)
         self.assertEqual(
             [suggestion.safety_score for suggestion in suggestions],
             sorted((suggestion.safety_score for suggestion in suggestions), reverse=True),


### PR DESCRIPTION
## Summary
- add an MVP dependency conflict predictor for apt and pip installs
- detect pre-install risks with confidence-scored findings
- rank safer resolution strategies before package changes
- document usage and add unit tests

## What was added
- `cx/dependency_conflict_predictor.py`
  - apt metadata checks (`Conflicts`, `Breaks`, missing dependencies)
  - pip constraint checks (direct mismatch + reverse dependency risk)
  - ranked suggestions and JSON/CLI output modes
- `tests/test_dependency_conflict_predictor.py`
  - version constraint behavior
  - apt conflict and not-found behavior
  - pip conflict detection
  - end-to-end prediction shape/suggestions
- `docs/dependency-conflict-predictor.md`
  - usage examples and exit code semantics
- `README.md`
  - feature command reference entry

## Validation
- `python3 -m unittest tests/test_dependency_conflict_predictor.py`

Closes #428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MVP pre-install dependency conflict predictor for apt and pip with per-finding confidence, ranked mitigation suggestions, CLI and JSON output, and exit-code signaling for CI.

* **Documentation**
  * Added docs and README entry describing checks, usage examples, output formats, confidence scoring, suggestions, and exit codes.

* **Tests**
  * Added unit and integration tests covering apt and pip conflict detection, constraint handling, reverse-dependency risks, suggestion ranking, and scoring.

* **Chores**
  * Added packaging library dependency to support PEP 440 version/specifier parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->