### PR TITLE
fix: Route unrecognized CLI input to cx ask (natural language)

### DIFF
--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -187,6 +187,11 @@ enum SubCommand {
     /// Manage AI models and settings
     #[command(name = "ai", about = "Manage AI models (download, status, etc.)")]
     AI(cli::ai::AICommand),
+
+    /// Catch-all: route unrecognized input to `cx ask` for natural language processing.
+    /// This allows `cx "analyze logs"` to work the same as `cx ask "analyze logs"`.
+    #[command(external_subcommand)]
+    NaturalLanguage(Vec<OsString>),
 }
 
 use termwiz::escape::osc::{
@@ -816,6 +821,26 @@ fn run() -> anyhow::Result<()> {
         SubCommand::Explain(cmd) => cmd.run(),
         SubCommand::Daemon(cmd) => cmd.run(),
         SubCommand::AI(cmd) => cmd.run(),
+        // Catch-all: route unrecognized commands to cx ask
+        // This makes `cx "analyze logs"` work like `cx ask "analyze logs"`
+        SubCommand::NaturalLanguage(args) => {
+            let query: Vec<String> = args
+                .into_iter()
+                .map(|s| s.to_string_lossy().into_owned())
+                .collect();
+            if query.is_empty() {
+                anyhow::bail!("No query provided. Usage: cx \"your question here\" or cx ask \"your question\"");
+            }
+            let ask = cli::ask::AskCommand {
+                query,
+                execute: false,
+                auto_confirm: false,
+                local_only: false,
+                format: "text".to_string(),
+                verbose: false,
+            };
+            ask.run()
+        }
     }
 }
 


### PR DESCRIPTION
**Fixes smoke test T04/T05 (P0): NL commands not working.**

## Problem
`cx "analyze logs for errors"` returned `unknown command: analyze` because clap's subcommand parser didn't recognize it.

## Solution
Added `#[command(external_subcommand)]` variant `NaturalLanguage(Vec<OsString>)` to the `SubCommand` enum. Unrecognized input is automatically routed to `cx ask`.

## Before
```
$ cx "analyze logs for errors"
error: unrecognized subcommand 'analyze'
```

## After
```
$ cx "analyze logs for errors"
# Same as: cx ask "analyze logs for errors"
# AI processes the natural language request
```

## Changes
- `wezterm/src/main.rs`: Added `NaturalLanguage` external_subcommand variant + dispatch handler